### PR TITLE
Run ansible-playbook directly instead of going through "python -u"

### DIFF
--- a/n_utils/includes/bake-image.sh
+++ b/n_utils/includes/bake-image.sh
@@ -284,7 +284,7 @@ cat > ansible.cfg << MARKER
 [defaults]
 retry_files_enabled = False
 MARKER
-if python -u $(which ansible-playbook) \
+if $(which ansible-playbook) \
   -vvvv \
   --flush-cache \
   $PLAYBOOK \


### PR DESCRIPTION
"python" is always Python 2, and Ansible may have been installed with pip3