### PR TITLE
Make sure setuptools is upgraded before installing

### DIFF
--- a/n_utils/includes/install_tools.sh
+++ b/n_utils/includes/install_tools.sh
@@ -31,7 +31,7 @@ if [ "$OS_TYPE" = "ubuntu" ]; then
   echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
 fi
 python -m pip install -U pip --ignore-installed
-pip install -U awscli boto3
+pip install -U awscli boto3 setuptools
 # If alpha, get first all non-alpha dependencies
 pip install -U "nameless-deploy-tools$DEPLOYTOOLS_VERSION" --ignore-installed
 if [ "$1" = "alpha" ]; then


### PR DESCRIPTION
Should fix errors like this:

```
Collecting nameless-deploy-tools
  Downloading nameless-deploy-tools-1.168.tar.gz (133 kB)
     |████████████████████████████████| 133 kB 10.5 MB/s 
    ERROR: Command errored out with exit status 1:
     command: /bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-R5bRbz/nameless-deploy-tools/setup.py'"'"'; __file__='"'"'/tmp/pip-install-R5bRbz/nameless-deploy-tools/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-efIUCG
         cwd: /tmp/pip-install-R5bRbz/nameless-deploy-tools/
    Complete output (47 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-R5bRbz/nameless-deploy-tools/setup.py", line 68, in <module>
        zip_safe=False)
      File "/usr/lib64/python2.7/distutils/core.py", line 112, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 265, in __init__
        self.fetch_build_eggs(attrs.pop('setup_requires'))
      File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 289, in fetch_build_eggs
        parse_requirements(requires), installer=self.fetch_build_egg
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 618, in resolve
        dist = best[req.key] = env.best_match(req, self, installer)
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 862, in best_match
        return self.obtain(req, installer) # try and download/install
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 874, in obtain
        return installer(requirement)
      File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 339, in fetch_build_egg
        return cmd.easy_install(req)
      File "/usr/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 623, in easy_install
        return self.install_item(spec, dist.location, tmpdir, deps)
      File "/usr/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 653, in install_item
        dists = self.install_eggs(spec, download, tmpdir)
      File "/usr/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 849, in install_eggs
        return self.build_and_install(setup_script, setup_base)
      File "/usr/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1130, in build_and_install
        self.run_setup(setup_script, setup_base, args)
      File "/usr/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1115, in run_setup
        run_setup(setup_script, args)
      File "/usr/lib/python2.7/site-packages/setuptools/sandbox.py", line 69, in run_setup
        lambda: execfile(
      File "/usr/lib/python2.7/site-packages/setuptools/sandbox.py", line 120, in run
        return func()
      File "/usr/lib/python2.7/site-packages/setuptools/sandbox.py", line 71, in <lambda>
        {'__file__':setup_script, '__name__':'__main__'}
      File "setup.py", line 21, in <module>
        python2_or_3_test_deps = ['pytest==4.6.11', 'pytest-mock==1.13.0', 'mock==3.0.5']
      File "/usr/lib64/python2.7/distutils/core.py", line 112, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 269, in __init__
        _Distribution.__init__(self,attrs)
      File "/usr/lib64/python2.7/distutils/dist.py", line 287, in __init__
        self.finalize_options()
      File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 302, in finalize_options
        ep.load()(self, ep.name, value)
      File "build/bdist.linux-x86_64/egg/setuptools_scm/integration.py", line 9, in version_keyword
      File "build/bdist.linux-x86_64/egg/setuptools_scm/version.py", line 60, in _warn_if_setuptools_outdated
    setuptools_scm.version.SetuptoolsOutdatedWarning: your setuptools is too old (<12)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

I can't seem to work around this since the playbook installs ndt before running preinstall.sh.