### PR TITLE
Remove errors on terminal if commands are not found

### DIFF
--- a/n_utils/includes/bake-docker.sh
+++ b/n_utils/includes/bake-docker.sh
@@ -95,7 +95,7 @@ if [ -n "$DOCKER_BAKE_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval "$(ndt assume-role "DOCKER_BAKE_ROLE_ARN")"
 elif [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval "$(ndt assume-role "$DEPLOY_ROLE_ARN")"
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval "$(assume-deploy-role.sh)"
 fi
 

--- a/n_utils/includes/bake-image.sh
+++ b/n_utils/includes/bake-image.sh
@@ -72,7 +72,7 @@ if [ -n "$BAKE_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $BAKE_ROLE_ARN)
 elif [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval "$(ndt assume-role "$DEPLOY_ROLE_ARN")"
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 

--- a/n_utils/includes/cloud_init_functions.sh
+++ b/n_utils/includes/cloud_init_functions.sh
@@ -51,7 +51,7 @@ EOF
 onexit () {
   echo -----------------------------------------------------------------
   set +e
-  if which fetch-secrets.sh > /dev/null 2>&1; then
+  if which fetch-secrets.sh &> /dev/null 2>&1; then
     fetch-secrets.sh logout
   fi
   signal-cf-status $status

--- a/n_utils/includes/deploy-azure.sh
+++ b/n_utils/includes/deploy-azure.sh
@@ -100,7 +100,7 @@ fi
 #If assume-azure-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_AZURE_SUBSCRIPTION" ] && [ -z "$AZURE_SUBSCRIPTION" ]; then
   eval $(ndt assume-role -s $DEPLOY_AZURE_SUBSCRIPTION)
-elif which assume-azure-deploy-role.sh > /dev/null && [ -z "$AZURE_SUBSCRIPTION" -o "$AZURE_SUBSCRIPTION" != "$DEPLOY_AZURE_SUBSCRIPTION" ]; then
+elif which assume-azure-deploy-role.sh &> /dev/null && [ -z "$AZURE_SUBSCRIPTION" -o "$AZURE_SUBSCRIPTION" != "$DEPLOY_AZURE_SUBSCRIPTION" ]; then
   eval $(assume-azure-deploy-role.sh)
 fi
 

--- a/n_utils/includes/deploy-cdk.sh
+++ b/n_utils/includes/deploy-cdk.sh
@@ -86,7 +86,7 @@ eval "$(ndt load-parameters "$component" -c "$cdk" -e -r)"
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 

--- a/n_utils/includes/deploy-serverless.sh
+++ b/n_utils/includes/deploy-serverless.sh
@@ -92,7 +92,7 @@ eval "$(ndt load-parameters "$component" -l "$serverless" -e -r)"
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 

--- a/n_utils/includes/deploy-stack.sh
+++ b/n_utils/includes/deploy-stack.sh
@@ -106,7 +106,7 @@ eval "$(ndt load-parameters "$component" -s "$stackName" -e -r)"
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 

--- a/n_utils/includes/deploy-terraform.sh
+++ b/n_utils/includes/deploy-terraform.sh
@@ -88,7 +88,7 @@ eval "$(ndt load-parameters "$component" -t "$terraform" -e -r)"
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 elif [ -n "$AWS_PROFILE" ]; then
   eval "$(ndt profile-to-env $AWS_PROFILE)"

--- a/n_utils/includes/terraform-pull-state.sh
+++ b/n_utils/includes/terraform-pull-state.sh
@@ -81,7 +81,7 @@ eval "$(ndt load-parameters "$component" -t "$terraform" -e -r)"
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 elif [ -n "$AWS_PROFILE" ]; then
   eval "$(ndt profile-to-env $AWS_PROFILE)"

--- a/n_utils/includes/undeploy-azure.sh
+++ b/n_utils/includes/undeploy-azure.sh
@@ -93,7 +93,7 @@ fi
 #If assume-azure-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_AZURE_SUBSCRIPTION" ] && [ -z "$AZURE_SUBSCRIPTION" ]; then
   eval $(ndt assume-role -s $DEPLOY_AZURE_SUBSCRIPTION)
-elif which assume-azure-deploy-role.sh > /dev/null && [ -z "$AZURE_SUBSCRIPTION" -o "$AZURE_SUBSCRIPTION" != "$DEPLOY_AZURE_SUBSCRIPTION" ]; then
+elif which assume-azure-deploy-role.sh &> /dev/null && [ -z "$AZURE_SUBSCRIPTION" -o "$AZURE_SUBSCRIPTION" != "$DEPLOY_AZURE_SUBSCRIPTION" ]; then
   eval $(assume-azure-deploy-role.sh)
 fi
 

--- a/n_utils/includes/undeploy-cdk.sh
+++ b/n_utils/includes/undeploy-cdk.sh
@@ -76,7 +76,7 @@ fi
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 

--- a/n_utils/includes/undeploy-serverless.sh
+++ b/n_utils/includes/undeploy-serverless.sh
@@ -76,7 +76,7 @@ fi
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 

--- a/n_utils/includes/undeploy-stack.sh
+++ b/n_utils/includes/undeploy-stack.sh
@@ -66,7 +66,7 @@ eval "$(ndt load-parameters "$image" -s "$stackName" -e)"
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 

--- a/n_utils/includes/undeploy-terraform.sh
+++ b/n_utils/includes/undeploy-terraform.sh
@@ -76,7 +76,7 @@ fi
 #If assume-deploy-role.sh is on the path, run it to assume the appropriate role for deployment
 if [ -n "$DEPLOY_ROLE_ARN" ] && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(ndt assume-role $DEPLOY_ROLE_ARN)
-elif which assume-deploy-role.sh > /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
+elif which assume-deploy-role.sh &> /dev/null && [ -z "$AWS_SESSION_TOKEN" ]; then
   eval $(assume-deploy-role.sh)
 fi
 


### PR DESCRIPTION
Without stderr redirect we get:
```sh
which non-existing > /dev/null
/usr/bin/which: no non-existing in ($PATH)
```