### PR TITLE
Windows bake fixes

### DIFF
--- a/n_utils/includes/bake-win-image.yml
+++ b/n_utils/includes/bake-win-image.yml
@@ -114,7 +114,11 @@
       name: [ "python" ]
       version: "{{ win_python_version }}"
   - win_chocolatey:
-      name: [ "awscli", "sync" ]
+      name: [ "sync" ]
+      ignore_checksums: yes
+    when: base_ami_id == "clean"
+  - win_chocolatey:
+      name: [ "awscli" ]
     when: base_ami_id == "clean"
   - win_shell: "C:\\nameless\\prepare.ps1"
     args:

--- a/n_utils/includes/win-userdata.txt.j2
+++ b/n_utils/includes/win-userdata.txt.j2
@@ -3,6 +3,7 @@
 $admin = [adsi]("WinNT://./administrator, user")
 $admin.PSBase.Invoke("SetPassword", "{{ ansible_ssh_pass }}")
 net user Administrator "{{ ansible_ssh_pass }}"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 Stop-Transcript


### PR DESCRIPTION
* the "sync" package was uninstallable due to some checksum mismatch
* TLS 1.2 needs to be enabled before attempting to download `ConfigureRemotingForAnsible.ps1` from GitHub, at least on older Windows versions