### PR TITLE
Bump nitor-vault requirement to 0.54

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ jmespath==0.10.0
     #   nameless-deploy-tools (setup.py)
 netifaces==0.11.0
     # via ec2-utils
-nitor-vault==0.53
+nitor-vault==0.54
     # via nameless-deploy-tools (setup.py)
 py==1.11.0
     # via retry


### PR DESCRIPTION
Fixes #18. nitor-vault is not installed directly, so we end up pulling the version defined here, not the latest available. Bumping to 0.54 should lead to `wmi` etc. being installed.