### PR TITLE
Define region when terminating old instances too

### DIFF
--- a/n_utils/includes/bake-image.yml
+++ b/n_utils/includes/bake-image.yml
@@ -21,6 +21,7 @@
   tasks:
   - amazon.aws.ec2_instance:
       state: terminated
+      region: "{{ aws_region }}"
       filters:
         "tag:environment": "nameless"
         "tag:Name": "{{ job_name }} prototype"


### PR DESCRIPTION
Fixes `The amazon.aws.ec2_instance module requires a region and none was found in configuration, environment variables or module parameters` error in bake-image.yml when environment is lacking.