### PR TITLE
Silence npm and pip checkcs for updating the tools, required funding etc

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -406,7 +406,7 @@ options:
 ```bash
 usage: ndt deploy-serverless [-d] [-h] component serverless-name
 
-Exports ndt parameters into component/serverless-name/variables.yml, runs npm i in the
+Exports ndt parameters into component/serverless-name/variables.yml, runs npm ci in the
 serverless project and runs sls deploy -s $paramEnvId for the same
 If pre_deploy.sh and post_deploy.sh exist and are executable in the subcompoent directory,
 they will be executed before and after the deployment, respectively.
@@ -418,7 +418,7 @@ positional arguments:
                   you would give sender
 
 optional arguments:
-  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and npm i
+  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and npm ci
   -v, --verbose verbose - verbose output from serverless framework
   -h, --help    show this help message and exit
 ```

--- a/n_utils/includes/creatable-templates/jenkins/post_install.sh
+++ b/n_utils/includes/creatable-templates/jenkins/post_install.sh
@@ -6,7 +6,7 @@ setup-fetch-secrets.sh vault
 
 pip install ansible pywinrm pylint wmi s3cmd
 
-npm i -g gulp browserify jshint
+npm i --no-update-notifier --no-fund --no-audit -g gulp browserify jshint
 
 install_cftools
 install_lein

--- a/n_utils/includes/deploy-serverless.sh
+++ b/n_utils/includes/deploy-serverless.sh
@@ -38,7 +38,7 @@ fi
 usage() {
   echo "usage: ndt deploy-serverless [-d] [-h] component serverless-name" >&2
   echo "" >&2
-  echo "Exports ndt parameters into component/serverless-name/variables.yml, runs npm i in the" >&2
+  echo "Exports ndt parameters into component/serverless-name/variables.yml, runs npm ci in the" >&2
   echo "serverless project and runs sls deploy -s \$paramEnvId for the same" >&2
   echo "If pre_deploy.sh and post_deploy.sh exist and are executable in the subcompoent directory," >&2
   echo "they will be executed before and after the deployment, respectively." >&2
@@ -50,7 +50,7 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and npm i"  >&2
+  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and npm ci"  >&2
   echo "  -v, --verbose verbose - verbose output from serverless framework"  >&2
   echo "  -h, --help    show this help message and exit"  >&2
   if "$@"; then
@@ -112,7 +112,7 @@ if [ -z "$SKIP_NPM" -o "$SKIP_NPM" = "n" ]; then
   if [ -n "$UNSAFE_NPM" -a "$UNSAFE_NPM" != "n" ]; then
     UNSAFE="--unsafe-perm"
   fi
-  npm i $UNSAFE
+  npm ci --no-update-notifier --no-fund --no-audit $UNSAFE
 fi
 
 if [ -n "$DRYRUN" ]; then

--- a/n_utils/includes/deploy-terraform.sh
+++ b/n_utils/includes/deploy-terraform.sh
@@ -52,7 +52,7 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and npm i"  >&2
+  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing"  >&2
   echo "  -h, --help    show this help message and exit"  >&2
   if "$@"; then
     echo "" >&2

--- a/n_utils/includes/install_tools.sh
+++ b/n_utils/includes/install_tools.sh
@@ -85,19 +85,19 @@ function install_awscliv2() {
   return 0
 }
 
-python -m pip install -U pip wheel --ignore-installed
+python -m pip install --disable-pip-version-check -U pip wheel --ignore-installed
 install_awscliv2
 # Setuptools installed with pip breaks the platform python setup on CentOS 8
 if [ "$OS_TYPE" = "centos" -a "$OS_VERSION" = "8" ]; then
-  pip install -U boto3
+  pip install --disable-pip-version-check -U boto3
 else
-  pip install -U boto3 setuptools
+  pip install --disable-pip-version-check -U boto3 setuptools
 fi
 # If alpha, get first all non-alpha dependencies
-pip install -U "nameless-deploy-tools$DEPLOYTOOLS_VERSION" --ignore-installed
+pip install --disable-pip-version-check -U "nameless-deploy-tools$DEPLOYTOOLS_VERSION" --ignore-installed
 if [ "$1" = "alpha" ]; then
   # Upgrade just ndt to alpha
-  pip install -U --pre --no-deps "nameless-deploy-tools" --ignore-installed
+  pip install --disable-pip-version-check -U --pre --no-deps "nameless-deploy-tools" --ignore-installed
 fi
 aws configure set default.s3.signature_version s3v4
 rm -f /opt/nameless/instance-data.json

--- a/n_utils/includes/prepare.ps1
+++ b/n_utils/includes/prepare.ps1
@@ -3,6 +3,6 @@ $output = "C:\nameless\VCForPython27.msi"
 (New-Object System.Net.WebClient).DownloadFile($url, $output)
 Start-Process msiexec -ArgumentList @("/i", "C:\nameless\VCForPython27.msi", "/passive", "/quiet") -NoNewWindow -Wait
 
-python.exe -m pip install -U pip
-python.exe -m pip install -U setuptools certifi
-pip install -U boto3 nameless-deploy-tools
+python.exe -m pip install --disable-pip-version-check -U pip
+python.exe -m pip install --disable-pip-version-check -U setuptools certifi
+pip install --disable-pip-version-check -U boto3 nameless-deploy-tools

--- a/n_utils/includes/tool_installers.sh
+++ b/n_utils/includes/tool_installers.sh
@@ -68,7 +68,7 @@ install_cftools() {
     curl -s https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar -xzvf -
   fi
   cd aws-cfn-bootstrap-*
-  pip install .
+  pip install --disable-pip-version-check .
   cd ..
 }
 install_maven() {


### PR DESCRIPTION
Mostly because they are annoying and the ci system does not need them during deploy time.
It might also make the builds faster over a slow connection since there are fewer sockets opened to the home base from npm/pip tools.