### PR TITLE
Replace ansible_ssh_foo with ansible_foo, fixes Windows builds

### DIFF
--- a/n_utils/includes/bake-image.sh
+++ b/n_utils/includes/bake-image.sh
@@ -187,7 +187,7 @@ if [ "$IMAGETYPE" != "windows" ]; then
   [ "$VOLUME_SIZE" ] || VOLUME_SIZE=8
 else
   WIN_PASSWD="$(tr -cd '[:alnum:]' < /dev/urandom | head -c16)"
-  PASSWD_ARG="{\"ansible_ssh_pass\": \"$WIN_PASSWD\","
+  PASSWD_ARG="{\"ansible_password\": \"$WIN_PASSWD\","
   PASSWD_ARG="$PASSWD_ARG \"ansible_winrm_operation_timeout_sec\": 60,"
   PASSWD_ARG="$PASSWD_ARG \"ansible_winrm_read_timeout_sec\": 70,"
   PASSWD_ARG="$PASSWD_ARG \"ansible_winrm_server_cert_validation\": \"ignore\","
@@ -313,7 +313,7 @@ if $(which ansible-playbook) \
   -e root_ami=$AMI \
   -e tstamp=$TSTAMP \
   -e aws_region=$REGION \
-  -e ansible_ssh_user=$SSH_USER \
+  -e ansible_user=$SSH_USER \
   -e imagedir="$(realpath "${imagedir}")" \
   -e subnet_id=$SUBNET \
   -e sg_id=$SECURITY_GROUP \

--- a/n_utils/includes/bake-win-image.yml
+++ b/n_utils/includes/bake-win-image.yml
@@ -87,7 +87,7 @@
   hosts: "{{ job_name }}_ami_instance"
   vars:
     ansible_connection: winrm
-    ansible_ssh_port: 5986
+    ansible_port: 5986
     ansible_winrm_server_cert_validation: ignore
   tasks:
   - name: Wait for system to become reachable

--- a/n_utils/includes/win-userdata-unclean.txt.j2
+++ b/n_utils/includes/win-userdata-unclean.txt.j2
@@ -1,7 +1,7 @@
 #jinja2: newline_sequence:'\r\n'
 <powershell>
 $admin = [adsi]("WinNT://./administrator, user")
-$admin.PSBase.Invoke("SetPassword", "{{ ansible_ssh_pass }}")
-net user Administrator "{{ ansible_ssh_pass }}"
+$admin.PSBase.Invoke("SetPassword", "{{ ansible_password }}")
+net user Administrator "{{ ansible_password }}"
 </powershell>
 <persist>true</persist>

--- a/n_utils/includes/win-userdata.txt.j2
+++ b/n_utils/includes/win-userdata.txt.j2
@@ -1,8 +1,8 @@
 #jinja2: newline_sequence:'\r\n'
 <powershell>
 $admin = [adsi]("WinNT://./administrator, user")
-$admin.PSBase.Invoke("SetPassword", "{{ ansible_ssh_pass }}")
-net user Administrator "{{ ansible_ssh_pass }}"
+$admin.PSBase.Invoke("SetPassword", "{{ ansible_password }}")
+net user Administrator "{{ ansible_password }}"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'


### PR DESCRIPTION
> Ansible 2.0 has deprecated the "ssh" from ansible_ssh_user, ansible_ssh_pass, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_password, ansible_host, and ansible_port. If using a version of Ansible prior to 2.0, the older style (ansible_ssh_*) should be used instead. The shorter variables are ignored, without warning, in older versions of Ansible.

The ansible Windows collection apparently no longer works with ansible_ssh_user, it needs ansible_user:

> ESTABLISH WINRM CONNECTION FOR USER: None on PORT 5986

Amazingly, ansible_ssh_pass has been sneakily reworded into ansible_password, so a simple search ad replace yields broken results.