### PR TITLE
Downgrade to Python 3.8.10 on Windows

### DIFF
--- a/n_utils/includes/bake-image.sh
+++ b/n_utils/includes/bake-image.sh
@@ -193,7 +193,7 @@ else
   PASSWD_ARG="$PASSWD_ARG \"ansible_winrm_server_cert_validation\": \"ignore\","
   PASSWD_ARG="$PASSWD_ARG \"prepare_script\": \"$(n-include prepare.ps1)\"}"
   [ "$VOLUME_SIZE" ] || VOLUME_SIZE=30
-  [ "$WIN_PYTHON_VERSION" ] || WIN_PYTHON_VERSION="3.9.13"
+  [ "$WIN_PYTHON_VERSION" ] || WIN_PYTHON_VERSION="3.8.10"
   extra_args[${#extra_args[@]}]=-e
   extra_args[${#extra_args[@]}]="win_python_version=$WIN_PYTHON_VERSION"
 fi


### PR DESCRIPTION
3.8.10 is as of right now the latest available 3.8.x available via Chocolatey. One of our dependencies is difficult/impossible to install/build on Windows on Python 3.9 so this is mainly a pragmatic solution for now.

See https://github.com/NitorCreations/ec2-utils/issues/4

Fixes #31