### PR TITLE
Serverless SSO-support

### DIFF
--- a/n_utils/__init__.py
+++ b/n_utils/__init__.py
@@ -102,6 +102,7 @@ NDT_ONLY = [
     "yaml-to-yaml=n_utils.cli:yaml_to_yaml",
     "upsert-codebuild-projects=n_utils.cli:cli_upsert_codebuild_projects",
     "upsert-dns-record=n_utils.cli:upsert_dns_record",
+    "update-sso-profile=n_utils.profile_util:cli_update_sso_profile",
     "deploy-connect=n_utils.cli:deploy_connect_contact_flows",
     "export-connect-contact-flow=n_utils.cli:export_connect_contact_flow",
     "list-connect-contact-flows=n_utils.cli:list_connect_contact_flows",

--- a/n_utils/profile_util.py
+++ b/n_utils/profile_util.py
@@ -141,6 +141,12 @@ def read_profile_expiry_epoc(profile, profile_type=None):
     return _epoc_secs(parse(read_profile_expiry(profile, profile_type=profile_type)).replace(tzinfo=tzutc()))
 
 
+def check_profile_expired(profile, profile_type=None):
+    return _epoc_secs(
+        parse(read_profile_expiry(profile, profile_type=profile_type)).replace(tzinfo=tzutc())
+    ) < _epoc_secs(datetime.now(tzutc()))
+
+
 def print_aws_profiles():
     """
     Prints profile names from credentials file (~/.aws/credentials),


### PR DESCRIPTION
Currently using serverless needs either the npm-package `aws-sso-creds-helper` or the usage of [Serverless Better Credentials](https://www.serverless.com/plugins/serverless-better-credentials). Neither of these solutions are satisfactory, first one requires another package and the second one doesn't work flawlessly with e.g. `sls invoke ...`.
Simple solution for this at least is that when enabling an SSO-profile, NDT also writes the profile to `~/.aws/credentials` so that Serverless Framework can be used seemlessly without any plugins.