### PR TITLE
run serverless commands through npx

### DIFF
--- a/n_utils/includes/deploy-serverless.sh
+++ b/n_utils/includes/deploy-serverless.sh
@@ -116,12 +116,12 @@ if [ -z "$SKIP_NPM" -o "$SKIP_NPM" = "n" ]; then
 fi
 
 if [ -n "$DRYRUN" ]; then
-  sls package $VERBOSE -s $paramEnvId
+  npx serverless package $VERBOSE -s $paramEnvId
   exit 0
 fi
 
 set -e
-sls deploy --conceal $VERBOSE -s $paramEnvId
+npx serverless deploy --conceal $VERBOSE -s $paramEnvId
 
 if [ -x "./post_deploy.sh" ]; then
   "./post_deploy.sh"

--- a/n_utils/includes/undeploy-serverless.sh
+++ b/n_utils/includes/undeploy-serverless.sh
@@ -87,4 +87,4 @@ ndt yaml-to-yaml "$component/serverless-$ORIG_SERVERLESS_NAME/template.yaml" > "
 
 cd "$component/serverless-$ORIG_SERVERLESS_NAME"
 
-sls remove -s $paramEnvId
+npx serverless remove -s $paramEnvId


### PR DESCRIPTION
Currently deploying to serverless requires `serverless` to be installed globally on the local machine. Running it through [npx](https://www.npmjs.com/package/npx) (which is installed by default with npm) removes this requirement and the serverless package can be executed without installing it locally.