### PR TITLE
Format shell code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,13 @@
 [*.sh]
-indent_style = space
-indent_size = 2
-shell_variant = bash
-binary_next_line = true
-switch_case_indent = true
-space_redirects = true
-keep_padding = true
+# see `man shfmt` for explanations
+binary_next_line = false
 function_next_line = false
+indent_size = 2
+indent_style = space
+keep_padding = true
+shell_variant = bash
+space_redirects = true
+switch_case_indent = true
 
 # Ignore the entire "third_party" directory.
 [third_party/**]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*.sh]
+indent_style = space
+indent_size = 2
+shell_variant = bash
+binary_next_line = true
+switch_case_indent = true
+space_redirects = true
+keep_padding = true
+function_next_line = false
+
+# Ignore the entire "third_party" directory.
+[third_party/**]
+ignore = true

--- a/bin/create-shell-archive.sh
+++ b/bin/create-shell-archive.sh
@@ -39,13 +39,13 @@ fi
 eof_marker="AR_EOF_MARKER_$(basename $(mktemp --dry-run | tr . _))"
 echo '#!/bin/bash -e'
 echo 'umask 077'
-for file ; do
-    echo 'echo "Extracting '"$file"'"'
-    echo 'mkdir -p "$(dirname '"'""$file""'"')"'
-    [ -e "$file" ]
-    echo 'cat > "'"$file"'" << '\'$eof_marker\'' || { echo "ERROR extracting file" ; exit 1 ; }'
-    cat "$file"
-    echo $eof_marker
-    mode=$(stat -c '%a' "$file")
-    echo 'chmod '"$mode"' "'"$file"'"'
+for file; do
+  echo 'echo "Extracting '"$file"'"'
+  echo 'mkdir -p "$(dirname '"'""$file""'"')"'
+  [ -e "$file" ]
+  echo 'cat > "'"$file"'" << '\'$eof_marker\'' || { echo "ERROR extracting file" ; exit 1 ; }'
+  cat "$file"
+  echo $eof_marker
+  mode=$(stat -c '%a' "$file")
+  echo 'chmod '"$mode"' "'"$file"'"'
 done

--- a/bin/encrypt-and-mount.sh
+++ b/bin/encrypt-and-mount.sh
@@ -53,7 +53,7 @@ if [ "$1" = "--help" -o "$1" = "-h" ]; then
 fi
 
 crypted_devices() {
-  for dev in  $(dmsetup ls --target crypt | grep -v "No devices found" | awk '{ print $1 }'); do
+  for dev in $(dmsetup ls --target crypt | grep -v "No devices found" | awk '{ print $1 }'); do
     echo -n "$dev "
     dmsetup deps $dev -o blkdevname | awk -NF '\\(|\\)' '{ print $2 }'
   done
@@ -90,7 +90,7 @@ chmod 600 $TMPDIR/disk.pwd
 dd if=/dev/urandom of=$TMPDIR/disk.pwd bs=512 count=4 status=none iflag=fullblock
 #Open plain dm-crypt mapping
 cryptsetup --cipher=aes-xts-plain64 --key-file=$TMPDIR/disk.pwd --key-size=512 \
-open --type=plain $DEVPATH $CRYPTDEV
+  open --type=plain $DEVPATH $CRYPTDEV
 # Get rid of keyfile
 umount -f $TMPDIR
 # Make sure the mount path is not already mounted

--- a/bin/ensure-letsencrypt-certs.sh
+++ b/bin/ensure-letsencrypt-certs.sh
@@ -71,7 +71,7 @@ for DOMAIN in "$@"; do
     chmod 600 $CERT
   fi
   if fetch-secrets.sh get 444 $CERT; then
-    VALID="$(openssl x509 -enddate -noout -in "$CERT" | cut -d= -f2- )"
+    VALID="$(openssl x509 -enddate -noout -in "$CERT" | cut -d= -f2-)"
     echo "Valid: $VALID"
     if ! openssl x509 -checkend $((RENEW_DAYS * 86400)) -noout -in "$CERT"; then
       renew_cert $DOMAIN

--- a/bin/lastpass-fetch-notes.sh
+++ b/bin/lastpass-fetch-notes.sh
@@ -55,7 +55,7 @@ if [ ! "$mode" ]; then
   usage
 fi
 
-for path ; do
+for path; do
   if [ "$path" = "--optional" ]; then
     optional=1
     continue
@@ -64,14 +64,14 @@ for path ; do
   DNAME="$(dirname "$path")"
   mkdir -p "$DNAME"
   if [ -e "$path" ]; then
-      TMPDIR=$(mktemp -d $path.XXXXXXX)
-      mv "$path" "$TMPDIR/"
+    TMPDIR=$(mktemp -d $path.XXXXXXX)
+    mv "$path" "$TMPDIR/"
   fi
   if ! lpass show --notes "$FNAME" > "$path"; then
     rm -f "$path"
     if [ -n "$TMPDIR" ]; then
-        mv "$TMPDIR/$FNAME" "$path"
-        rm -rf "$TMPDIR"
+      mv "$TMPDIR/$FNAME" "$path"
+      rm -rf "$TMPDIR"
     fi
     if [ ! "$optional" ]; then
       echo "ERROR: Failed to get file $path"

--- a/bin/setup-fetch-secrets.sh
+++ b/bin/setup-fetch-secrets.sh
@@ -36,15 +36,15 @@ usage() {
   echo "  lpass|s3|vault   the selected secrets backend." >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -h, --help  show this help message and exit" >&2  exit 1
+  echo "  -h, --help  show this help message and exit" exit 1 >&2
 }
 
 if [ "$1" = "--help" -o "$1" = "-h" ]; then
   usage
 fi
 
-if [ "$EUID" -ne 0 ]
-  then echo "Please run as root"
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root"
   exit 1
 fi
 if ! [[ "$1" =~ ^lpass$|^s3$|^vault$ ]]; then

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -17,10 +17,10 @@ docker manifest annotate --arch amd64 nitor/ndt:$NEW_VERSION nitor/ndt:amd64-$NE
 docker manifest annotate --arch arm64 nitor/ndt:$NEW_VERSION nitor/ndt:arm64-$NEW_VERSION
 docker manifest push nitor/ndt:$NEW_VERSION
 
-if ! echo "$NEW_VERSION" | grep "a" >/dev/null; then
-    docker manifest rm nitor/ndt:latest || true
-    docker manifest create nitor/ndt:latest nitor/ndt:amd64-$NEW_VERSION nitor/ndt:arm64-$NEW_VERSION
-    docker manifest annotate --arch amd64 nitor/ndt:latest nitor/ndt:amd64-$NEW_VERSION
-    docker manifest annotate --arch arm64 nitor/ndt:latest nitor/ndt:arm64-$NEW_VERSION
-    docker manifest push nitor/ndt:latest
+if ! echo "$NEW_VERSION" | grep "a" > /dev/null; then
+  docker manifest rm nitor/ndt:latest || true
+  docker manifest create nitor/ndt:latest nitor/ndt:amd64-$NEW_VERSION nitor/ndt:arm64-$NEW_VERSION
+  docker manifest annotate --arch amd64 nitor/ndt:latest nitor/ndt:amd64-$NEW_VERSION
+  docker manifest annotate --arch arm64 nitor/ndt:latest nitor/ndt:arm64-$NEW_VERSION
+  docker manifest push nitor/ndt:latest
 fi

--- a/docker-base/start-docker.sh
+++ b/docker-base/start-docker.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
 /usr/local/bin/dockerd \
-    --host=unix:///var/run/docker.sock \
-    --host=tcp://127.0.0.1:2375 \
-    --storage-driver=overlay2 &>/var/log/docker.log &
+  --host=unix:///var/run/docker.sock \
+  --host=tcp://127.0.0.1:2375 \
+  --storage-driver=overlay2 &> /var/log/docker.log &
 
 tries=0
 d_timeout=10
-until docker info >/dev/null 2>&1; do
-    if [ "$tries" -gt "$d_timeout" ]; then
-        cat /var/log/docker.log
-        echo 'Timed out trying to connect to internal docker host.' >&2
-        exit 1
-    fi
-    tries=$(($tries + 1))
-    sleep 1
+until docker info > /dev/null 2>&1; do
+  if [ "$tries" -gt "$d_timeout" ]; then
+    cat /var/log/docker.log
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  tries=$(($tries + 1))
+  sleep 1
 done

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -852,7 +852,7 @@ Load parameters from infra*.properties files in the order:
 
     See https://www.tldp.org/LDP/Bash-Beginners-Guide/html/sect_10_03.html
     (arrays not supported)
-    
+
 
 positional arguments:
   component             Compenent to descend into
@@ -1453,7 +1453,7 @@ Creates or updates codebuild projects to deploy or bake ndt subcomponents in the
         - Needed for bakes and for example serverless python dockerized dependencies
     * SKIP_BUILD_JOB - skip creating build jobs where this parameter is \'y\'
     * SKIP_IMAGE_JOB, SKIP_DOCKER_JOB, SKIP_SERVERLESS_JOB, SKIP_CDK_JOB, SKIP_TERRAFORM_JOB - skip creating jobs where these parameters are \'y\' and match the subcomponent type
-    
+
 
 options:
   -h, --help     show this help message and exit
@@ -1814,4 +1814,3 @@ positional arguments
 optional arguments:
   -h, --help  show this help message and exit
 ```
-

--- a/n_utils/includes/aws_domainjoin.sh
+++ b/n_utils/includes/aws_domainjoin.sh
@@ -39,408 +39,407 @@ MAX_APPEND_DIGITS=5
 NETBIOS_COMPUTER_NAME_LEN=15
 
 get_default_hostname() {
-    INSTANCE_NAME=$(hostname --short) 2>/dev/null
+  INSTANCE_NAME=$(hostname --short) 2> /dev/null
 
-    # Naming conventions in Active Directory
-    # https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and
-    RANDOM_COMPUTER_NAME=$(head -c 512 /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)
-    COMPUTER_NAME=$(echo EC2AMAZ-$RANDOM_COMPUTER_NAME)
+  # Naming conventions in Active Directory
+  # https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and
+  RANDOM_COMPUTER_NAME=$(head -c 512 /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)
+  COMPUTER_NAME=$(echo EC2AMAZ-$RANDOM_COMPUTER_NAME)
 }
 
 ##################################################
 ## Set hostname to NETBIOS computer name #########
 ##################################################
 set_hostname() {
-    HOSTNAME_LEN=$(expr length $COMPUTER_NAME)
-    if [ $HOSTNAME_LEN -gt $NETBIOS_COMPUTER_NAME_LEN ]; then
-       echo "**Failed: Hostname exceeds NetBIOS hostname length : $HOSTNAME_LEN"
-       exit 1
-    fi
+  HOSTNAME_LEN=$(expr length $COMPUTER_NAME)
+  if [ $HOSTNAME_LEN -gt $NETBIOS_COMPUTER_NAME_LEN ]; then
+    echo "**Failed: Hostname exceeds NetBIOS hostname length : $HOSTNAME_LEN"
+    exit 1
+  fi
 
-    HOSTNAMECTL=$(which hostnamectl)
-    if [ ! -z "$HOSTNAMECTL" ]; then
-        hostnamectl set-hostname $COMPUTER_NAME.$DIRECTORY_NAME >/dev/null
-    else
-        hostname $COMPUTER_NAME.$DIRECTORY_NAME >/dev/null
-    fi
-    if [ $? -ne 0 ]; then echo "***Failed: set_hostname(): set hostname failed" && exit 1; fi
+  HOSTNAMECTL=$(which hostnamectl)
+  if [ ! -z "$HOSTNAMECTL" ]; then
+    hostnamectl set-hostname $COMPUTER_NAME.$DIRECTORY_NAME > /dev/null
+  else
+    hostname $COMPUTER_NAME.$DIRECTORY_NAME > /dev/null
+  fi
+  if [ $? -ne 0 ]; then echo "***Failed: set_hostname(): set hostname failed" && exit 1; fi
 
-    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-hostname.html
-    if [ -f /etc/sysconfig/network ]; then
-            sed -i "s/HOSTNAME=.*$//g" /etc/sysconfig/network
-        echo "HOSTNAME=$COMPUTER_NAME.$DIRECTORY_NAME" >> /etc/sysconfig/network
-    fi
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-hostname.html
+  if [ -f /etc/sysconfig/network ]; then
+    sed -i "s/HOSTNAME=.*$//g" /etc/sysconfig/network
+    echo "HOSTNAME=$COMPUTER_NAME.$DIRECTORY_NAME" >> /etc/sysconfig/network
+  fi
 }
 
 get_list_of_computers() {
-    LDAP_BASE_DN=$(echo $DIRECTORY_NAME | awk -F\. '{ for (i = 1; i <= NF; i++) { if (i != NF) printf "DC=%s,",$i ; else printf "DC=%s", $i} }')
-    DIRNAME_UPPER=$(echo "$DIRECTORY_NAME" | tr [:lower:] [:upper:])
-    ldapsearch -H ldap://$DIRECTORY_NAME -b $LDAP_BASE_DN 'objectClass=computer' -D "$DOMAIN_USERNAME@$DIRNAME_UPPER" -w "$DOMAIN_PASSWORD"  | grep "cn:" | sed 's/cn://g'
+  LDAP_BASE_DN=$(echo $DIRECTORY_NAME | awk -F\. '{ for (i = 1; i <= NF; i++) { if (i != NF) printf "DC=%s,",$i ; else printf "DC=%s", $i} }')
+  DIRNAME_UPPER=$(echo "$DIRECTORY_NAME" | tr [:lower:] [:upper:])
+  ldapsearch -H ldap://$DIRECTORY_NAME -b $LDAP_BASE_DN 'objectClass=computer' -D "$DOMAIN_USERNAME@$DIRNAME_UPPER" -w "$DOMAIN_PASSWORD" | grep "cn:" | sed 's/cn://g'
 }
 
 cleanup_temp_files() {
-    rm -f $AWS_CLI_INSTALL_DIR/ldap_search.txt
-    rm -f $AWS_CLI_INSTALL_DIR/all_suffixes.txt
-    rm -f $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt
-    rm -f $AWS_CLI_INSTALL_DIR/possible_suffixes.txt
-    rm -f $AWS_CLI_INSTALL_DIR/awscliv2.zip
+  rm -f $AWS_CLI_INSTALL_DIR/ldap_search.txt
+  rm -f $AWS_CLI_INSTALL_DIR/all_suffixes.txt
+  rm -f $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt
+  rm -f $AWS_CLI_INSTALL_DIR/possible_suffixes.txt
+  rm -f $AWS_CLI_INSTALL_DIR/awscliv2.zip
 }
 
 #################################################
 ## find unused hostname after appending digits ##
 #################################################
 find_unused_hostname() {
-    if [ -z $SET_HOSTNAME ]; then
-        echo "**Failed: Argument SET_HOSTNAME is blank"
-        exit 1
+  if [ -z $SET_HOSTNAME ]; then
+    echo "**Failed: Argument SET_HOSTNAME is blank"
+    exit 1
+  fi
+
+  if [ -z $SET_HOSTNAME_APPEND_NUM_DIGITS ]; then
+    COMPUTER_NAME=$SET_HOSTNAME
+    return
+  fi
+
+  COMPUTER_NAME=""
+
+  NUM_DIGITS=1
+  echo "SET_HOSTNAME_APPEND_NUM_DIGITS = $SET_HOSTNAME_APPEND_NUM_DIGITS"
+  for i in $(seq $SET_HOSTNAME_APPEND_NUM_DIGITS); do
+    NUM_DIGITS=$(expr $NUM_DIGITS \* 10)
+  done
+  NUM_DIGITS=$(expr $NUM_DIGITS - 1)
+
+  # If the number of digits is 5, $AWS_CLI_INSTALL_DIR/all_suffixes.txt will
+  # have numbers 00000-99999, one per line.
+  # If the number of digits is 2, the file will have numbers from 00 to 99, one per line.
+  for i in $(seq 0 $NUM_DIGITS); do
+    if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 1 ]; then
+      printf "%01d\n" $i
+    fi
+    if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 2 ]; then
+      printf "%02d\n" $i
+    fi
+    if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 3 ]; then
+      printf "%03d\n" $i
+    fi
+    if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 4 ]; then
+      printf "%04d\n" $i
+    fi
+    if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 5 ]; then
+      printf "%05d\n" $i
+    fi
+  done > $AWS_CLI_INSTALL_DIR/all_suffixes.txt
+
+  MAX_RETRIES=5
+  for i in $(seq 1 $MAX_RETRIES); do
+    get_list_of_computers > $AWS_CLI_INSTALL_DIR/ldap_search.txt
+    if [ ! -s $AWS_CLI_INSTALL_DIR/ldap_search.txt ]; then
+      echo "**Failed: Could not get list of computers"
+      exit 1
     fi
 
-    if [ -z $SET_HOSTNAME_APPEND_NUM_DIGITS ]; then
-        COMPUTER_NAME=$SET_HOSTNAME
-        return
+    # $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt has hosts
+    # with the same hostname prefix
+    # and then remove the hostname in each line so only the number suffixes remain.
+    # This gives us the list of suffixes that already exist.
+    cat $AWS_CLI_INSTALL_DIR/ldap_search.txt \
+                                           | grep -iP "^[ ]*$SET_HOSTNAME\d{$SET_HOSTNAME_APPEND_NUM_DIGITS}$" \
+                                                                     | sort | sed "s/$SET_HOSTNAME//gI" | tr -d ' ' \
+      > $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt
+
+    # The 'comm' utility does 'set complement' between
+    # $AWS_CLI_INSTALL_DIR/all_suffixes.txt
+    # and $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt
+    # to find suffixes that do not exist in ldap_filtered_hosts.
+    comm -23 $AWS_CLI_INSTALL_DIR/all_suffixes.txt \
+      $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt \
+      > $AWS_CLI_INSTALL_DIR/possible_suffixes.txt
+    if [ $? -ne 0 ]; then
+      echo "**Failed: Could not execute comm utility"
+      cleanup_temp_files
+      exit 1
     fi
 
-    COMPUTER_NAME=""
+    num_lines=$(wc -l $AWS_CLI_INSTALL_DIR/possible_suffixes.txt | awk '{ print $1 }')
 
-    NUM_DIGITS=1
-    echo "SET_HOSTNAME_APPEND_NUM_DIGITS = $SET_HOSTNAME_APPEND_NUM_DIGITS"
-    for i in $(seq $SET_HOSTNAME_APPEND_NUM_DIGITS)
-    do
-        NUM_DIGITS=$(expr $NUM_DIGITS \* 10 )
-    done
-    NUM_DIGITS=$(expr $NUM_DIGITS - 1)
+    if [ $num_lines -eq 0 ]; then
+      echo "**Failed: Could not find unused hostnames"
+      exit 1
+    fi
 
-    # If the number of digits is 5, $AWS_CLI_INSTALL_DIR/all_suffixes.txt will
-    # have numbers 00000-99999, one per line.
-    # If the number of digits is 2, the file will have numbers from 00 to 99, one per line.
-    for i in $(seq 0 $NUM_DIGITS)
-    do
-        if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 1 ]; then
-            printf "%01d\n" $i
-        fi
-        if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 2 ]; then
-            printf "%02d\n" $i
-        fi
-        if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 3 ]; then
-            printf "%03d\n" $i
-        fi
-        if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 4 ]; then
-            printf "%04d\n" $i
-        fi
-        if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -eq 5 ]; then
-            printf "%05d\n" $i
-        fi
-    done > $AWS_CLI_INSTALL_DIR/all_suffixes.txt
+    # When we have a list of possible hosts, one in each line, we can use
+    # a random number to choose one of the unused suffixes.
+    RANDOM_VALUE=$(head -c 512 /dev/urandom | xxd -p | tr -dc '0-9' \
+                                                                  | fold -w $MAX_APPEND_DIGITS | head -n 1)
+    if [ -z $RANDOM_VALUE ]; then
+      LINE_N = 1
+    else
+      LINE_N=$(expr $RANDOM_VALUE % $num_lines)
+      if [ $LINE_N -eq 0 -o $num_lines -eq 1 ]; then
+        LINE_N=1
+      fi
+    fi
+    HOSTNAME_SUFFIX=$(sed -n "$LINE_N"p < $AWS_CLI_INSTALL_DIR/possible_suffixes.txt)
 
-    MAX_RETRIES=5
-    for i in $(seq 1 $MAX_RETRIES)
-    do
-        get_list_of_computers > $AWS_CLI_INSTALL_DIR/ldap_search.txt
-        if [ ! -s $AWS_CLI_INSTALL_DIR/ldap_search.txt ]; then
-            echo "**Failed: Could not get list of computers"
-            exit 1
-        fi
+    POSSIBLE_HOSTNAME=$SET_HOSTNAME$HOSTNAME_SUFFIX
+    if [ "$POSSIBLE_HOSTNAME" = "$SET_HOSTNAME" ]; then
+      echo "**Failed: Could not find a possible hostname"
+      cleanup_temp_files
+      exit 1
+    fi
 
-        # $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt has hosts
-        # with the same hostname prefix
-        # and then remove the hostname in each line so only the number suffixes remain.
-        # This gives us the list of suffixes that already exist.
-        cat $AWS_CLI_INSTALL_DIR/ldap_search.txt \
-            | grep -iP "^[ ]*$SET_HOSTNAME\d{$SET_HOSTNAME_APPEND_NUM_DIGITS}$" \
-            | sort | sed "s/$SET_HOSTNAME//gI" | tr -d ' ' \
-              > $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt
+    echo "[$i] Trying possible hostname $POSSIBLE_HOSTNAME"
+    cat $AWS_CLI_INSTALL_DIR/ldap_search.txt | grep -i "$POSSIBLE_HOSTNAME$"
+    if [ $? -ne 0 ]; then
+      echo "[$i] Found unused hostname as $POSSIBLE_HOSTNAME"
+      COMPUTER_NAME=$POSSIBLE_HOSTNAME
+      cleanup_temp_files
+      break
+    fi
+  done
 
-        # The 'comm' utility does 'set complement' between
-        # $AWS_CLI_INSTALL_DIR/all_suffixes.txt
-        # and $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt
-        # to find suffixes that do not exist in ldap_filtered_hosts.
-        comm -23 $AWS_CLI_INSTALL_DIR/all_suffixes.txt \
-            $AWS_CLI_INSTALL_DIR/ldap_filtered_hosts.txt \
-                > $AWS_CLI_INSTALL_DIR/possible_suffixes.txt
-        if [ $? -ne 0 ]; then
-            echo "**Failed: Could not execute comm utility"
-            cleanup_temp_files
-            exit 1
-        fi
-
-        num_lines=$(wc -l $AWS_CLI_INSTALL_DIR/possible_suffixes.txt | awk '{ print $1 }')
-
-        if [ $num_lines -eq 0 ]; then
-           echo "**Failed: Could not find unused hostnames"
-           exit 1
-        fi
-
-        # When we have a list of possible hosts, one in each line, we can use
-        # a random number to choose one of the unused suffixes.
-        RANDOM_VALUE=$(head -c 512 /dev/urandom | xxd -p | tr -dc '0-9' \
-                            | fold -w $MAX_APPEND_DIGITS | head -n 1)
-        if [ -z $RANDOM_VALUE ]; then
-           LINE_N = 1
-        else
-           LINE_N=$(expr $RANDOM_VALUE % $num_lines)
-           if [ $LINE_N -eq 0 -o $num_lines -eq 1 ]; then
-              LINE_N=1
-           fi
-        fi
-        HOSTNAME_SUFFIX=$(sed -n "$LINE_N"p < $AWS_CLI_INSTALL_DIR/possible_suffixes.txt)
-
-        POSSIBLE_HOSTNAME=$SET_HOSTNAME$HOSTNAME_SUFFIX
-        if [ "$POSSIBLE_HOSTNAME" = "$SET_HOSTNAME" ]; then
-            echo "**Failed: Could not find a possible hostname"
-            cleanup_temp_files
-            exit 1
-        fi
-
-        echo "[$i] Trying possible hostname $POSSIBLE_HOSTNAME"
-        cat $AWS_CLI_INSTALL_DIR/ldap_search.txt | grep -i "$POSSIBLE_HOSTNAME$"
-        if [ $? -ne 0 ]; then
-            echo "[$i] Found unused hostname as $POSSIBLE_HOSTNAME"
-            COMPUTER_NAME=$POSSIBLE_HOSTNAME
-            cleanup_temp_files
-            break
-        fi
-    done
-
-    cleanup_temp_files
+  cleanup_temp_files
 }
 
 ##################################################
 ## Download AWS CLI zip file #####################
 ##################################################
 download_awscli_zipfile() {
-    MAX_RETRIES=3
-    CURL_DOWNLOAD_URL="$1"
-    if [ -z "$1" ]; then
-       echo "***Failed: No URL argument provided for curl"
-       exit 1
-    fi
-    echo "CURL download url is $CURL_DOWNLOAD_URL"
+  MAX_RETRIES=3
+  CURL_DOWNLOAD_URL="$1"
+  if [ -z "$1" ]; then
+    echo "***Failed: No URL argument provided for curl"
+    exit 1
+  fi
+  echo "CURL download url is $CURL_DOWNLOAD_URL"
 
-    MAX_RETRIES=3
-    STATUS=1
-    for i in $(seq 1 $MAX_RETRIES)
-    do
-       echo "[$i] Attempt installing AWS CLI by using curl"
-       curl --fail $CURL_DOWNLOAD_URL -o "$AWS_CLI_INSTALL_DIR/awscliv2.zip"
-       STATUS=$?
-       if [ $STATUS -eq 0 ]; then
-          break
-       else
-           curl -1 --fail $CURL_DOWNLOAD_URL -o "$AWS_CLI_INSTALL_DIR/awscliv2.zip"
-           STATUS=$?
-           if [ $STATUS -eq 0 ]; then
-              break
-           fi
-       fi
-       sleep 3
-    done
-
-    if [ $STATUS -ne 0 ]; then
-       echo "***Failed: curl $CURL_DOWNLOAD_URL failed."
-       exit 1
+  MAX_RETRIES=3
+  STATUS=1
+  for i in $(seq 1 $MAX_RETRIES); do
+    echo "[$i] Attempt installing AWS CLI by using curl"
+    curl --fail $CURL_DOWNLOAD_URL -o "$AWS_CLI_INSTALL_DIR/awscliv2.zip"
+    STATUS=$?
+    if [ $STATUS -eq 0 ]; then
+      break
+    else
+      curl -1 --fail $CURL_DOWNLOAD_URL -o "$AWS_CLI_INSTALL_DIR/awscliv2.zip"
+      STATUS=$?
+      if [ $STATUS -eq 0 ]; then
+        break
+      fi
     fi
+    sleep 3
+  done
+
+  if [ $STATUS -ne 0 ]; then
+    echo "***Failed: curl $CURL_DOWNLOAD_URL failed."
+    exit 1
+  fi
 }
 
 ###################################################
 ## Check permissions of AWS CLI install directory #
 ###################################################
 check_awscli_install_dir() {
-   if [ ! -d $AWS_CLI_INSTALL_DIR ]; then
-       echo "***Failed: AWS CLI install dir $AWS_CLI_INSTALL_DIR does not exist"
-       exit 1
-   fi
+  if [ ! -d $AWS_CLI_INSTALL_DIR ]; then
+    echo "***Failed: AWS CLI install dir $AWS_CLI_INSTALL_DIR does not exist"
+    exit 1
+  fi
 
-   # POSIX ls specification - https://pubs.opengroup.org/onlinepubs/9699919799/
-   # If the -l option is specified, the following information
-   # shall be written for files other than character special
-   # and block special files: "%s %u %s %s %u %s %s\n", <file mode>, <number of links>, <owner name>, <group name>, <size>, <date and time>, <pathname>
-   ls -ld $AWS_CLI_INSTALL_DIR
-   if [ $? -ne 0 ]; then
-       echo "***Failed: ls -ld $AWS_CLI_INSTALL_DIR"
-       exit 1
-   fi
-   AWS_CLI_INSTALL_DIR_LS_LD=$(ls -ld $AWS_CLI_INSTALL_DIR)
-   AWS_CLI_INSTALL_DIR_OWNER=$(echo $AWS_CLI_INSTALL_DIR_LS_LD | awk '{print $3}')
-   id -u $AWS_CLI_INSTALL_DIR_OWNER
-   if [ $? -ne 0 ]; then
-       echo "***Failed: id command"
-       exit 1
-   fi
-   ID=$(id -u $AWS_CLI_INSTALL_DIR_OWNER)
-   if [ $ID != "0" ]; then
-       echo "***Failed: AWS CLI install dir user is not root"
-       exit 1
-   fi
-   AWS_CLI_INSTALL_DIR_PERMISSIONS=$(echo $AWS_CLI_INSTALL_DIR_LS_LD | awk '{print $1}' | cut -c 5-)
-   if echo "$AWS_CLI_INSTALL_DIR_PERMISSIONS" | grep -e "------" ; then
-       echo "Permissions check successful for AWS CLI install directory"
-   else
-       echo "***Failed: Wrong permissions for $AWS_CLI_INSTALL_DIR_PERMISSIONS"
-       exit 1
-   fi
+  # POSIX ls specification - https://pubs.opengroup.org/onlinepubs/9699919799/
+  # If the -l option is specified, the following information
+  # shall be written for files other than character special
+  # and block special files: "%s %u %s %s %u %s %s\n", <file mode>, <number of links>, <owner name>, <group name>, <size>, <date and time>, <pathname>
+  ls -ld $AWS_CLI_INSTALL_DIR
+  if [ $? -ne 0 ]; then
+    echo "***Failed: ls -ld $AWS_CLI_INSTALL_DIR"
+    exit 1
+  fi
+  AWS_CLI_INSTALL_DIR_LS_LD=$(ls -ld $AWS_CLI_INSTALL_DIR)
+  AWS_CLI_INSTALL_DIR_OWNER=$(echo $AWS_CLI_INSTALL_DIR_LS_LD | awk '{print $3}')
+  id -u $AWS_CLI_INSTALL_DIR_OWNER
+  if [ $? -ne 0 ]; then
+    echo "***Failed: id command"
+    exit 1
+  fi
+  ID=$(id -u $AWS_CLI_INSTALL_DIR_OWNER)
+  if [ $ID != "0" ]; then
+    echo "***Failed: AWS CLI install dir user is not root"
+    exit 1
+  fi
+  AWS_CLI_INSTALL_DIR_PERMISSIONS=$(echo $AWS_CLI_INSTALL_DIR_LS_LD | awk '{print $1}' | cut -c 5-)
+  if echo "$AWS_CLI_INSTALL_DIR_PERMISSIONS" | grep -e "------"; then
+    echo "Permissions check successful for AWS CLI install directory"
+  else
+    echo "***Failed: Wrong permissions for $AWS_CLI_INSTALL_DIR_PERMISSIONS"
+    exit 1
+  fi
 }
 
 ##################################################
 ########## Install components ####################
 ##################################################
 install_components() {
-    LINUX_DISTRO=$(cat /etc/os-release | grep NAME | awk -F'=' '{print $2}')
-    LINUX_DISTRO_VERSION_ID=$(cat /etc/os-release | grep VERSION_ID | awk -F'=' '{print $2}' | tr -d '"')
-    if [ -z $LINUX_DISTRO_VERSION_ID ]; then
-       echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
-       exit 1
-    fi
+  LINUX_DISTRO=$(cat /etc/os-release | grep NAME | awk -F'=' '{print $2}')
+  LINUX_DISTRO_VERSION_ID=$(cat /etc/os-release | grep VERSION_ID | awk -F'=' '{print $2}' | tr -d '"')
+  if [ -z $LINUX_DISTRO_VERSION_ID ]; then
+    echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
+    exit 1
+  fi
 
-    if grep 'CentOS' /etc/os-release 1>/dev/null 2>/dev/null; then
-        if [ "$LINUX_DISTRO_VERSION_ID" -lt "7" ] ; then
-            echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
-            exit 1
-        fi
-        LINUX_DISTRO='CentOS'
-        # yum -y update
-        ## yum update takes too long
-        yum -y install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation unzip bind-utils python3 openldap-clients vim-common >/dev/null
-        if [ $? -ne 0 ]; then echo "install_components(): yum install errors for CentOS" && return 1; fi
-    elif grep -e 'Red Hat' /etc/os-release 1>/dev/null 2>/dev/null; then
-        LINUX_DISTRO='RHEL'
-        RHEL_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
-        RHEL_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
-        if [ $RHEL_MAJOR_VERSION -eq "7" ] && [ ! -z $RHEL_MINOR_VERSION ] && [ $RHEL_MINOR_VERSION -lt "6" ]; then
-            # RHEL 7.5 and below are not supported
-            echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
-            exit 1
-        fi
-        if [ $RHEL_MAJOR_VERSION -eq "7" ] && [ -z $RHEL_MINOR_VERSION ]; then
-            # RHEL 7 is not supported
-            echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
-            exit 1
-        fi
-        # yum -y update
-        ## yum update takes too long
-        # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/deploying_different_types_of_servers/index
-        yum -y  install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation vim unzip bind-utils python3 openldap-clients NetworkManager >/dev/null
-        if [ $? -ne 0 ]; then echo "install_components(): yum install errors for Red Hat" && return 1; fi
-    elif grep -e 'Fedora' /etc/os-release 1>/dev/null 2>/dev/null; then
-        LINUX_DISTRO='Fedora'
-        ## yum update takes too long, but it is unavoidable here.
-        yum -y update
-        yum -y  install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation vim unzip bind-utils python3 openldap-clients vim-common NetworkManager >/dev/null
-        if [ $? -ne 0 ]; then echo "install_components(): yum install errors for Fedora" && return 1; fi
-        systemctl restart dbus
-    elif grep 'Amazon Linux' /etc/os-release 1>/dev/null 2>/dev/null; then
-         LINUX_DISTRO='AMAZON_LINUX'
-         # yum -y update
-         ## yum update takes too long
-         yum -y  install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation unzip bind-utils python3 openldap-clients vim-common network-manager >/dev/null
-         if [ $? -ne 0 ]; then echo "install_components(): yum install errors for Amazon Linux" && return 1; fi
-    elif grep 'Ubuntu' /etc/os-release 1>/dev/null 2>/dev/null; then
-         LINUX_DISTRO='UBUNTU'
-         UBUNTU_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
-         UBUNTU_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
-         if [ $UBUNTU_MAJOR_VERSION -lt "14" ]; then
-            # Ubuntu versions below 14.04 are not supported
-            echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
-            exit 1
-         fi
-         # set DEBIAN_FRONTEND variable to noninteractive to skip any interactive post-install configuration steps.
-         export DEBIAN_FRONTEND=noninteractive
-         apt-get -y update
-         if [ $? -ne 0 ]; then echo "install_components(): apt-get update errors for Ubuntu" && return 1; fi
-         apt-get -yq install realmd adcli winbind samba libnss-winbind libpam-winbind libpam-krb5 krb5-config krb5-locales krb5-user packagekit  ntp unzip dnsutils python3 ldap-utils network-manager > /dev/null
-         if [ $? -ne 0 ]; then echo "install_components(): apt-get install errors for Ubuntu" && return 1; fi
-         # Disable Reverse DNS resolution. Ubuntu Instances must be reverse-resolvable in DNS before the realm will work.
-         sed -i "s/default_realm.*$/default_realm = $REALM\n\trdns = false/g" /etc/krb5.conf
-         if [ $? -ne 0 ]; then echo "install_components(): access errors to /etc/krb5.conf"; return 1; fi
-         if ! grep "Ubuntu 16.04" /etc/os-release 2>/dev/null; then
-             pam-auth-update --enable mkhomedir
-         fi
-    elif grep 'SUSE Linux' /etc/os-release 1>/dev/null 2>/dev/null; then
-         SUSE_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
-         SUSE_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
-         if [ "$SUSE_MAJOR_VERSION" -lt "15" ]; then
-            echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
-            exit 1
-         fi
-         if [ "$SUSE_MAJOR_VERSION" -eq "15" ]; then
-            sudo SUSEConnect -p PackageHub/15.1/x86_64
-         fi
-         LINUX_DISTRO='SUSE'
-         sudo zypper update -y
-         sudo zypper -n install realmd adcli sssd sssd-tools sssd-ad samba-client krb5-client samba-winbind krb5-client bind-utils python3 openldap2-client NetworkManager
-         if [ $? -ne 0 ]; then
-            return 1
-         fi
-    elif grep 'Debian' /etc/os-release; then
-         DEBIAN_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
-         DEBIAN_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
-         if [ "$DEBIAN_MAJOR_VERSION" -lt "9" ]; then
-            echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
-            exit 1
-         fi
-         apt-get -y update
-         LINUX_DISTRO='DEBIAN'
-         DEBIAN_FRONTEND=noninteractive apt-get -yq install realmd adcli winbind samba libnss-winbind libpam-winbind libpam-krb5 krb5-config krb5-locales krb5-user packagekit ntp unzip dnsutils python3 ldapscripts network-manager > /dev/null
-         if [ $? -ne 0 ]; then
-            return 1
-         fi
+  if grep 'CentOS' /etc/os-release 1> /dev/null 2> /dev/null; then
+    if [ "$LINUX_DISTRO_VERSION_ID" -lt "7" ]; then
+      echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
+      exit 1
     fi
-
-    check_awscli_install_dir
-    if uname -a | grep -e "x86_64" -e "amd64"; then
-        download_awscli_zipfile "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-    elif uname -a | grep "aarch64"; then
-        download_awscli_zipfile "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    else
-        echo "***Failed: install_components processor type is unsupported." && exit 1
+    LINUX_DISTRO='CentOS'
+    # yum -y update
+    ## yum update takes too long
+    yum -y install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation unzip bind-utils python3 openldap-clients vim-common > /dev/null
+    if [ $? -ne 0 ]; then echo "install_components(): yum install errors for CentOS" && return 1; fi
+  elif grep -e 'Red Hat' /etc/os-release 1> /dev/null 2> /dev/null; then
+    LINUX_DISTRO='RHEL'
+    RHEL_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
+    RHEL_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
+    if [ $RHEL_MAJOR_VERSION -eq "7" ] && [ ! -z $RHEL_MINOR_VERSION ] && [ $RHEL_MINOR_VERSION -lt "6" ]; then
+      # RHEL 7.5 and below are not supported
+      echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
+      exit 1
     fi
+    if [ $RHEL_MAJOR_VERSION -eq "7" ] && [ -z $RHEL_MINOR_VERSION ]; then
+      # RHEL 7 is not supported
+      echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
+      exit 1
+    fi
+    # yum -y update
+    ## yum update takes too long
+    # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/deploying_different_types_of_servers/index
+    yum -y install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation vim unzip bind-utils python3 openldap-clients NetworkManager > /dev/null
+    if [ $? -ne 0 ]; then echo "install_components(): yum install errors for Red Hat" && return 1; fi
+  elif grep -e 'Fedora' /etc/os-release 1> /dev/null 2> /dev/null; then
+    LINUX_DISTRO='Fedora'
+    ## yum update takes too long, but it is unavoidable here.
+    yum -y update
+    yum -y install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation vim unzip bind-utils python3 openldap-clients vim-common NetworkManager > /dev/null
+    if [ $? -ne 0 ]; then echo "install_components(): yum install errors for Fedora" && return 1; fi
+    systemctl restart dbus
+  elif grep 'Amazon Linux' /etc/os-release 1> /dev/null 2> /dev/null; then
+    LINUX_DISTRO='AMAZON_LINUX'
+    # yum -y update
+    ## yum update takes too long
+    yum -y install realmd adcli oddjob-mkhomedir oddjob samba-winbind-clients samba-winbind samba-common-tools samba-winbind-krb5-locator krb5-workstation unzip bind-utils python3 openldap-clients vim-common network-manager > /dev/null
+    if [ $? -ne 0 ]; then echo "install_components(): yum install errors for Amazon Linux" && return 1; fi
+  elif grep 'Ubuntu' /etc/os-release 1> /dev/null 2> /dev/null; then
+    LINUX_DISTRO='UBUNTU'
+    UBUNTU_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
+    UBUNTU_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
+    if [ $UBUNTU_MAJOR_VERSION -lt "14" ]; then
+      # Ubuntu versions below 14.04 are not supported
+      echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
+      exit 1
+    fi
+    # set DEBIAN_FRONTEND variable to noninteractive to skip any interactive post-install configuration steps.
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get -y update
+    if [ $? -ne 0 ]; then echo "install_components(): apt-get update errors for Ubuntu" && return 1; fi
+    apt-get -yq install realmd adcli winbind samba libnss-winbind libpam-winbind libpam-krb5 krb5-config krb5-locales krb5-user packagekit ntp unzip dnsutils python3 ldap-utils network-manager > /dev/null
+    if [ $? -ne 0 ]; then echo "install_components(): apt-get install errors for Ubuntu" && return 1; fi
+    # Disable Reverse DNS resolution. Ubuntu Instances must be reverse-resolvable in DNS before the realm will work.
+    sed -i "s/default_realm.*$/default_realm = $REALM\n\trdns = false/g" /etc/krb5.conf
+    if [ $? -ne 0 ]; then
+      echo "install_components(): access errors to /etc/krb5.conf"
+      return 1
+    fi
+    if ! grep "Ubuntu 16.04" /etc/os-release 2> /dev/null; then
+      pam-auth-update --enable mkhomedir
+    fi
+  elif grep 'SUSE Linux' /etc/os-release 1> /dev/null 2> /dev/null; then
+    SUSE_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
+    SUSE_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
+    if [ "$SUSE_MAJOR_VERSION" -lt "15" ]; then
+      echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
+      exit 1
+    fi
+    if [ "$SUSE_MAJOR_VERSION" -eq "15" ]; then
+      sudo SUSEConnect -p PackageHub/15.1/x86_64
+    fi
+    LINUX_DISTRO='SUSE'
+    sudo zypper update -y
+    sudo zypper -n install realmd adcli sssd sssd-tools sssd-ad samba-client krb5-client samba-winbind krb5-client bind-utils python3 openldap2-client NetworkManager
+    if [ $? -ne 0 ]; then
+      return 1
+    fi
+  elif grep 'Debian' /etc/os-release; then
+    DEBIAN_MAJOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $1}')
+    DEBIAN_MINOR_VERSION=$(echo $LINUX_DISTRO_VERSION_ID | awk -F'.' '{print $2}')
+    if [ "$DEBIAN_MAJOR_VERSION" -lt "9" ]; then
+      echo "**Failed : Unsupported OS version $LINUX_DISTRO : $LINUX_DISTRO_VERSION_ID"
+      exit 1
+    fi
+    apt-get -y update
+    LINUX_DISTRO='DEBIAN'
+    DEBIAN_FRONTEND=noninteractive apt-get -yq install realmd adcli winbind samba libnss-winbind libpam-winbind libpam-krb5 krb5-config krb5-locales krb5-user packagekit ntp unzip dnsutils python3 ldapscripts network-manager > /dev/null
+    if [ $? -ne 0 ]; then
+      return 1
+    fi
+  fi
 
-    unzip -o "$AWS_CLI_INSTALL_DIR"/awscliv2.zip 1>/dev/null
-    if [ $? -ne 0 ]; then echo "***Failed: unzip of awscliv2.zip" && exit 1; fi
-    "$AWS_CLI_INSTALL_DIR"/aws/install -u 1>/dev/null
-    if [ $? -ne 0 ]; then echo "***Failed: aws cli install" && exit 1; fi
-    return 0
+  check_awscli_install_dir
+  if uname -a | grep -e "x86_64" -e "amd64"; then
+    download_awscli_zipfile "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+  elif uname -a | grep "aarch64"; then
+    download_awscli_zipfile "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  else
+    echo "***Failed: install_components processor type is unsupported." && exit 1
+  fi
+
+  unzip -o "$AWS_CLI_INSTALL_DIR"/awscliv2.zip 1> /dev/null
+  if [ $? -ne 0 ]; then echo "***Failed: unzip of awscliv2.zip" && exit 1; fi
+  "$AWS_CLI_INSTALL_DIR"/aws/install -u 1> /dev/null
+  if [ $? -ne 0 ]; then echo "***Failed: aws cli install" && exit 1; fi
+  return 0
 }
 
 ######################################################################
 ##### Retrieve Service Account Credentials from Secrets Manager   ####
 ######################################################################
 get_servicecreds() {
-    SECRET_ID="${SECRET_ID_PREFIX}/$DIRECTORY_ID/seamless-domain-join"
-    SECRET_VALUE=$($AWSCLI secretsmanager get-secret-value --secret-id "$SECRET_ID" --region $REGION --query "SecretString"  --output text 2>/dev/null)
-    if [ $? -ne 0 ]; then
-        PARENT_DIRECTORY_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].OwnerDirectoryDescription.DirectoryId | [0]" | sed 's/"//g')
-        if [ $? -ne 0 ] || [ -z "$PARENT_DIRECTORY_ID" ] || [ "$PARENT_DIRECTORY_ID" = null ]; then
-           echo "***Failed: Cannot find parent directory Id"
-           exit 1
-        fi
-        PARENT_ACCOUNT_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].OwnerDirectoryDescription.AccountId | [0]" | sed 's/"//g')
-        if [ $? -ne 0 ] || [ -z "$PARENT_ACCOUNT_ID" ] || [ "$PARENT_ACCOUNT_ID" = null ]; then
-           echo "***Failed: Cannot find parent account Id"
-           exit 1
-        fi
-        SECRET_ID="arn:aws:secretsmanager:${REGION}:${PARENT_ACCOUNT_ID}:secret:aws/directory-services/${PARENT_DIRECTORY_ID}/seamless-domain-join"
-        SECRET_VALUE=$($AWSCLI secretsmanager get-secret-value --secret-id "$SECRET_ID" --region $REGION --query 'SecretString' --output text 2>/dev/null)
-        if [ $? -ne 0 ] || [ -z "$SECRET_VALUE" ]; then
-           echo "***Failed: aws secretsmanager get-secret-value"
-           exit 1
-        fi
+  SECRET_ID="${SECRET_ID_PREFIX}/$DIRECTORY_ID/seamless-domain-join"
+  SECRET_VALUE=$($AWSCLI secretsmanager get-secret-value --secret-id "$SECRET_ID" --region $REGION --query "SecretString" --output text 2> /dev/null)
+  if [ $? -ne 0 ]; then
+    PARENT_DIRECTORY_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].OwnerDirectoryDescription.DirectoryId | [0]" | sed 's/"//g')
+    if [ $? -ne 0 ] || [ -z "$PARENT_DIRECTORY_ID" ] || [ "$PARENT_DIRECTORY_ID" = null ]; then
+      echo "***Failed: Cannot find parent directory Id"
+      exit 1
     fi
+    PARENT_ACCOUNT_ID=$($AWSCLI ds describe-directories --region $REGION --query "DirectoryDescriptions[?DirectoryId =='$DIRECTORY_ID'].OwnerDirectoryDescription.AccountId | [0]" | sed 's/"//g')
+    if [ $? -ne 0 ] || [ -z "$PARENT_ACCOUNT_ID" ] || [ "$PARENT_ACCOUNT_ID" = null ]; then
+      echo "***Failed: Cannot find parent account Id"
+      exit 1
+    fi
+    SECRET_ID="arn:aws:secretsmanager:${REGION}:${PARENT_ACCOUNT_ID}:secret:aws/directory-services/${PARENT_DIRECTORY_ID}/seamless-domain-join"
+    SECRET_VALUE=$($AWSCLI secretsmanager get-secret-value --secret-id "$SECRET_ID" --region $REGION --query 'SecretString' --output text 2> /dev/null)
+    if [ $? -ne 0 ] || [ -z "$SECRET_VALUE" ]; then
+      echo "***Failed: aws secretsmanager get-secret-value"
+      exit 1
+    fi
+  fi
 
-    if [ -n "$(command -v python3)" ]; then
-        PYTHON=$(which python3)
-    else
-        PYTHON=$(which python)
-    fi
-    DOMAIN_USERNAME=$(echo "$SECRET_VALUE" | $PYTHON -c 'import sys, json; obj=json.load(sys.stdin); print(obj["awsSeamlessDomainUsername"])')
-    if [ $? -ne 0 ] || [ -z "$DOMAIN_USERNAME" ]; then
-       echo "***Failed: Invalid DOMAIN_USERNAME"
-       exit 1
-    fi
-    DOMAIN_PASSWORD=$(echo "$SECRET_VALUE" | $PYTHON -c 'import sys, json; obj=json.load(sys.stdin); print(obj["awsSeamlessDomainPassword"])')
-    if [ $? -ne 0 ] || [ -z "$DOMAIN_PASSWORD" ]; then
-        echo "***Failed: Invalid DOMAIN_PASSWORD"
-        exit 1
-    fi
+  if [ -n "$(command -v python3)" ]; then
+    PYTHON=$(which python3)
+  else
+    PYTHON=$(which python)
+  fi
+  DOMAIN_USERNAME=$(echo "$SECRET_VALUE" | $PYTHON -c 'import sys, json; obj=json.load(sys.stdin); print(obj["awsSeamlessDomainUsername"])')
+  if [ $? -ne 0 ] || [ -z "$DOMAIN_USERNAME" ]; then
+    echo "***Failed: Invalid DOMAIN_USERNAME"
+    exit 1
+  fi
+  DOMAIN_PASSWORD=$(echo "$SECRET_VALUE" | $PYTHON -c 'import sys, json; obj=json.load(sys.stdin); print(obj["awsSeamlessDomainPassword"])')
+  if [ $? -ne 0 ] || [ -z "$DOMAIN_PASSWORD" ]; then
+    echo "***Failed: Invalid DOMAIN_PASSWORD"
+    exit 1
+  fi
 }
 
 ##################################################
@@ -448,69 +447,68 @@ get_servicecreds() {
 ## to prevent overwriting of resolv.conf    ######
 ##################################################
 setup_resolv_conf_and_dhclient_conf() {
-    if [ ! -z "$DNS_IP_ADDRESS1" ] && [ ! -z "$DNS_IP_ADDRESS2" ]; then
-        touch /etc/resolv.conf
-        mv /etc/resolv.conf /etc/resolv.conf.backup."$CURTIME"
-        echo ";Generated by Domain Join SSMDocument" > /etc/resolv.conf
-        echo "search $DIRECTORY_NAME" >> /etc/resolv.conf
-        echo "nameserver $DNS_IP_ADDRESS1" >> /etc/resolv.conf
-        echo "nameserver $DNS_IP_ADDRESS2" >> /etc/resolv.conf
-        touch /etc/dhcp/dhclient.conf
-        mv /etc/dhcp/dhclient.conf /etc/dhcp/dhclient.conf.backup."$CURTIME"
-        echo "supersede domain-name-servers $DNS_IP_ADDRESS1, $DNS_IP_ADDRESS2;" > /etc/dhcp/dhclient.conf
-    elif [ ! -z "$DNS_IP_ADDRESS1" ] && [ -z "$DNS_IP_ADDRESS2" ]; then
-        touch /etc/resolv.conf
-        mv /etc/resolv.conf /etc/resolv.conf.backup."$CURTIME"
-        echo ";Generated by Domain Join SSMDocument" > /etc/resolv.conf
-        echo "search $DIRECTORY_NAME" >> /etc/resolv.conf
-        echo "nameserver $DNS_IP_ADDRESS1" >> /etc/resolv.conf
-        touch /etc/dhcp/dhclient.conf
-        mv /etc/dhcp/dhclient.conf /etc/dhcp/dhclient.conf.backup."$CURTIME"
-        echo "supersede domain-name-servers $DNS_IP_ADDRESS1;" > /etc/dhcp/dhclient.conf
-    elif [ -z "$DNS_IP_ADDRESS1" ] && [ ! -z "$DNS_IP_ADDRESS2" ]; then
-        touch /etc/resolv.conf
-        mv /etc/resolv.conf /etc/resolv.conf.backup."$CURTIME"
-        echo ";Generated by Domain Join SSMDocument" > /etc/resolv.conf
-        echo "search $DIRECTORY_NAME" >> /etc/resolv.conf
-        echo "nameserver $DNS_IP_ADDRESS2" >> /etc/resolv.conf
-        touch /etc/dhcp/dhclient.conf
-        mv /etc/dhcp/dhclient.conf /etc/dhcp/dhclient.conf.backup."$CURTIME"
-        echo "supersede domain-name-servers $DNS_IP_ADDRESS2;" > /etc/dhcp/dhclient.conf
-    else
-        echo "***Failed: No DNS IPs available" && exit 1
-    fi
+  if [ ! -z "$DNS_IP_ADDRESS1" ] && [ ! -z "$DNS_IP_ADDRESS2" ]; then
+    touch /etc/resolv.conf
+    mv /etc/resolv.conf /etc/resolv.conf.backup."$CURTIME"
+    echo ";Generated by Domain Join SSMDocument" > /etc/resolv.conf
+    echo "search $DIRECTORY_NAME" >> /etc/resolv.conf
+    echo "nameserver $DNS_IP_ADDRESS1" >> /etc/resolv.conf
+    echo "nameserver $DNS_IP_ADDRESS2" >> /etc/resolv.conf
+    touch /etc/dhcp/dhclient.conf
+    mv /etc/dhcp/dhclient.conf /etc/dhcp/dhclient.conf.backup."$CURTIME"
+    echo "supersede domain-name-servers $DNS_IP_ADDRESS1, $DNS_IP_ADDRESS2;" > /etc/dhcp/dhclient.conf
+  elif [ ! -z "$DNS_IP_ADDRESS1" ] && [ -z "$DNS_IP_ADDRESS2" ]; then
+    touch /etc/resolv.conf
+    mv /etc/resolv.conf /etc/resolv.conf.backup."$CURTIME"
+    echo ";Generated by Domain Join SSMDocument" > /etc/resolv.conf
+    echo "search $DIRECTORY_NAME" >> /etc/resolv.conf
+    echo "nameserver $DNS_IP_ADDRESS1" >> /etc/resolv.conf
+    touch /etc/dhcp/dhclient.conf
+    mv /etc/dhcp/dhclient.conf /etc/dhcp/dhclient.conf.backup."$CURTIME"
+    echo "supersede domain-name-servers $DNS_IP_ADDRESS1;" > /etc/dhcp/dhclient.conf
+  elif [ -z "$DNS_IP_ADDRESS1" ] && [ ! -z "$DNS_IP_ADDRESS2" ]; then
+    touch /etc/resolv.conf
+    mv /etc/resolv.conf /etc/resolv.conf.backup."$CURTIME"
+    echo ";Generated by Domain Join SSMDocument" > /etc/resolv.conf
+    echo "search $DIRECTORY_NAME" >> /etc/resolv.conf
+    echo "nameserver $DNS_IP_ADDRESS2" >> /etc/resolv.conf
+    touch /etc/dhcp/dhclient.conf
+    mv /etc/dhcp/dhclient.conf /etc/dhcp/dhclient.conf.backup."$CURTIME"
+    echo "supersede domain-name-servers $DNS_IP_ADDRESS2;" > /etc/dhcp/dhclient.conf
+  else
+    echo "***Failed: No DNS IPs available" && exit 1
+  fi
 }
 
 ##################################################
 ## Set PEER_DNS to yes ###########################
 ##################################################
 set_peer_dns() {
-    for f in $(ls /etc/sysconfig/network-scripts/ifcfg-*)
-    do
-        if echo $f | grep "lo"; then
-            continue
-        fi
-        if ! grep PEERDNS $f; then
-            echo "" >> $f
-            echo PEERDNS=yes >> $f
-        fi
-    done
+  for f in $(ls /etc/sysconfig/network-scripts/ifcfg-*); do
+    if echo $f | grep "lo"; then
+      continue
+    fi
+    if ! grep PEERDNS $f; then
+      echo "" >> $f
+      echo PEERDNS=yes >> $f
+    fi
+  done
 }
 
 ##################################################
 ## Print shell variables #########################
 ##################################################
 print_vars() {
-    echo "REGION = $REGION"
-    echo "DIRECTORY_ID = $DIRECTORY_ID"
-    echo "DIRECTORY_NAME = $DIRECTORY_NAME"
-    echo "DIRECTORY_OU = $DIRECTORY_OU"
-    echo "REALM = $REALM"
-    echo "DNS_IP_ADDRESS1 = $DNS_IP_ADDRESS1"
-    echo "DNS_IP_ADDRESS2 = $DNS_IP_ADDRESS2"
-    echo "COMPUTER_NAME = $COMPUTER_NAME"
-    echo "hostname = $(hostname)"
-    echo "LINUX_DISTRO = $LINUX_DISTRO"
+  echo "REGION = $REGION"
+  echo "DIRECTORY_ID = $DIRECTORY_ID"
+  echo "DIRECTORY_NAME = $DIRECTORY_NAME"
+  echo "DIRECTORY_OU = $DIRECTORY_OU"
+  echo "REALM = $REALM"
+  echo "DNS_IP_ADDRESS1 = $DNS_IP_ADDRESS1"
+  echo "DNS_IP_ADDRESS2 = $DNS_IP_ADDRESS2"
+  echo "COMPUTER_NAME = $COMPUTER_NAME"
+  echo "hostname = $(hostname)"
+  echo "LINUX_DISTRO = $LINUX_DISTRO"
 }
 
 #########################################################
@@ -519,11 +517,10 @@ print_vars() {
 # Unable to perform DNS Update.                         #
 #########################################################
 configure_hosts_file() {
-    fullhost="${COMPUTER_NAME}.${DIRECTORY_NAME}"  # ,, means lowercase since bash v4
-    ip_address="$(ip -o -4 addr show eth0 | awk '{print $4}' | cut -d/ -f1)"
-    cleanup_comment='# Generated by Domain Join SSMDocument'
-    sed -i".orig" -r\
-        "/^.*${cleanup_comment}/d;\
+  fullhost="${COMPUTER_NAME}.${DIRECTORY_NAME}" # ,, means lowercase since bash v4
+  ip_address="$(ip -o -4 addr show eth0 | awk '{print $4}' | cut -d/ -f1)"
+  cleanup_comment='# Generated by Domain Join SSMDocument'
+  sed -i".orig" -r "/^.*${cleanup_comment}/d;\
         /^127.0.0.1\s+localhost\s*/a\\${ip_address} ${fullhost} ${COMPUTER_NAME} ${cleanup_comment}" /etc/hosts
 }
 
@@ -531,16 +528,16 @@ configure_hosts_file() {
 ## Restart NetworkManager if present ####################
 #########################################################
 restart_network_manager() {
-    if [ -d /etc/NetworkManager/conf.d/ ]; then
-       systemctl restart NetworkManager
-       if [ $? -ne 0 ]; then
-          service NetworkManager restart
-       fi
-       if [ $? -ne 0 ]; then
-         echo "**Failed: NetworkManager failed"
-         exit 1
-       fi
+  if [ -d /etc/NetworkManager/conf.d/ ]; then
+    systemctl restart NetworkManager
+    if [ $? -ne 0 ]; then
+      service NetworkManager restart
     fi
+    if [ $? -ne 0 ]; then
+      echo "**Failed: NetworkManager failed"
+      exit 1
+    fi
+  fi
 }
 
 ##################################################
@@ -549,27 +546,27 @@ restart_network_manager() {
 ## configuration files.                          #
 ##################################################
 do_dns_config() {
-    # Prevent Network Manager from overwriting resolv.conf
-    # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/manually-configuring-the-etc-resolv-conf-file_configuring-and-managing-networking
-    if [ -d /etc/NetworkManager/conf.d/ ]; then
-        echo "[main]" > /etc/NetworkManager/conf.d/90-dns-none.conf
-        echo "dns=none" >> /etc/NetworkManager/conf.d/90-dns-none.conf
-        if [ $? -ne 0 ]; then
-            echo "**Failed: Writing to /etc/NetworkManager/conf.d/90-dns-none.conf"
-            exit 1
-        fi
-        restart_network_manager
+  # Prevent Network Manager from overwriting resolv.conf
+  # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/manually-configuring-the-etc-resolv-conf-file_configuring-and-managing-networking
+  if [ -d /etc/NetworkManager/conf.d/ ]; then
+    echo "[main]" > /etc/NetworkManager/conf.d/90-dns-none.conf
+    echo "dns=none" >> /etc/NetworkManager/conf.d/90-dns-none.conf
+    if [ $? -ne 0 ]; then
+      echo "**Failed: Writing to /etc/NetworkManager/conf.d/90-dns-none.conf"
+      exit 1
     fi
+    restart_network_manager
+  fi
 
-    setup_resolv_conf_and_dhclient_conf
-    if [ $LINUX_DISTRO = 'AMAZON_LINUX' ]; then
-        set_peer_dns
-    fi
+  setup_resolv_conf_and_dhclient_conf
+  if [ $LINUX_DISTRO = 'AMAZON_LINUX' ]; then
+    set_peer_dns
+  fi
 
-    if [ $LINUX_DISTRO = "UBUNTU" ]; then
-        if [ -d /etc/netplan ]; then
-            # Ubuntu 18.04
-            cat << EOF | tee /etc/netplan/99-custom-dns.yaml
+  if [ $LINUX_DISTRO = "UBUNTU" ]; then
+    if [ -d /etc/netplan ]; then
+      # Ubuntu 18.04
+      cat << EOF | tee /etc/netplan/99-custom-dns.yaml
 network:
     version: 2
     ethernets:
@@ -579,26 +576,26 @@ network:
             dhcp4-overrides:
                 use-dns: false
 EOF
-            netplan apply
-            if [ $? -ne 0 ]; then echo "***Failed: do_dns_config(): netplan apply failed" && exit 1; fi
-            # Seems to fail otherwise
-            sleep 15
-        fi
+      netplan apply
+      if [ $? -ne 0 ]; then echo "***Failed: do_dns_config(): netplan apply failed" && exit 1; fi
+      # Seems to fail otherwise
+      sleep 15
     fi
+  fi
 
-    if [ $LINUX_DISTRO = "RHEL" ] || [ $LINUX_DISTRO = "Fedora" ]; then
-        set_peer_dns
-        if [ -f /etc/NetworkManager/NetworkManager.conf ]; then
-            cp /etc/NetworkManager/NetworkManager.conf /etc/NetworkManager/NetworkManager.conf."$CURTIME"
-            cat /etc/NetworkManager/NetworkManager.conf."$CURTIME" | sed "s/\[main\]/[main]\ndns=none/g" > /etc/NetworkManager/NetworkManager.conf
-        fi
+  if [ $LINUX_DISTRO = "RHEL" ] || [ $LINUX_DISTRO = "Fedora" ]; then
+    set_peer_dns
+    if [ -f /etc/NetworkManager/NetworkManager.conf ]; then
+      cp /etc/NetworkManager/NetworkManager.conf /etc/NetworkManager/NetworkManager.conf."$CURTIME"
+      cat /etc/NetworkManager/NetworkManager.conf."$CURTIME" | sed "s/\[main\]/[main]\ndns=none/g" > /etc/NetworkManager/NetworkManager.conf
     fi
+  fi
 
-    if [ $LINUX_DISTRO = "CentOS" ]; then
-        set_peer_dns
-    fi
+  if [ $LINUX_DISTRO = "CentOS" ]; then
+    set_peer_dns
+  fi
 
-    restart_network_manager
+  restart_network_manager
 }
 
 ##################################################
@@ -606,9 +603,9 @@ EOF
 ## by using nslookup command                    ##
 ##################################################
 resolve_name_to_ip() {
-    (
-        nslookup "$1"| tail -n +3 | sed -n 's/Address:\s*//p'
-    ) && return 0 || return 1
+  (
+    nslookup "$1" | tail -n +3 | sed -n 's/Address:\s*//p'
+  ) && return 0 || return 1
 }
 
 ##################################################
@@ -616,69 +613,67 @@ resolve_name_to_ip() {
 ## sets are used.                               ##
 ##################################################
 is_directory_reachable() {
-    grep "Generated by Domain Join SSMDocument" /etc/resolv.conf
-    if [ $? -ne 0 ]; then
-        echo "**Failed: /etc/resolv.conf was overwritten"
-        exit 1
-    fi
-    DNS_IPS=$(resolve_name_to_ip $DIRECTORY_NAME)
-    if [ $? -ne 0 ]; then
-        echo "***Failed: Cannot resolve domain name $DIRECTORY_NAME" && return 1
-    fi
-    echo -e "Successfully resolve domain name $DIRECTORY_NAME to IP address(es):\n$DNS_IPS"
+  grep "Generated by Domain Join SSMDocument" /etc/resolv.conf
+  if [ $? -ne 0 ]; then
+    echo "**Failed: /etc/resolv.conf was overwritten"
+    exit 1
+  fi
+  DNS_IPS=$(resolve_name_to_ip $DIRECTORY_NAME)
+  if [ $? -ne 0 ]; then
+    echo "***Failed: Cannot resolve domain name $DIRECTORY_NAME" && return 1
+  fi
+  echo -e "Successfully resolve domain name $DIRECTORY_NAME to IP address(es):\n$DNS_IPS"
 
-    return 0
+  return 0
 }
 
 ##################################################
 ## Join Linux instance to AWS Directory Service ##
 ##################################################
 do_domainjoin() {
-    MAX_RETRIES=10
-    for i in $(seq 1 $MAX_RETRIES)
-    do
-        if [ -z "$DIRECTORY_OU" ]; then
-            LOG_MSG=$(echo $DOMAIN_PASSWORD | realm join --client-software=winbind -U ${DOMAIN_USERNAME}@${DIRECTORY_NAME} "$DIRECTORY_NAME" -v 2>&1)
-        else
-            LOG_MSG=$(echo $DOMAIN_PASSWORD | realm join --client-software=winbind -U ${DOMAIN_USERNAME}@${DIRECTORY_NAME} "$DIRECTORY_NAME" --computer-ou="$DIRECTORY_OU" -v 2>&1)
-        fi
-        STATUS=$?
-        if [ $STATUS -eq 0 ]; then
-            break
-        else
-            if echo "$LOG_MSG" | grep -q "Already joined to this domain"; then
-                echo "do_domainjoin(): Already joined to this domain : $LOG_MSG"
-                STATUS=0
-                break
-            fi
-        fi
-        sleep 10
-    done
-
-    if [ $STATUS -ne 0 ]; then
-        echo "***Failed: realm join failed" && exit 1
+  MAX_RETRIES=10
+  for i in $(seq 1 $MAX_RETRIES); do
+    if [ -z "$DIRECTORY_OU" ]; then
+      LOG_MSG=$(echo $DOMAIN_PASSWORD | realm join --client-software=winbind -U ${DOMAIN_USERNAME}@${DIRECTORY_NAME} "$DIRECTORY_NAME" -v 2>&1)
+    else
+      LOG_MSG=$(echo $DOMAIN_PASSWORD | realm join --client-software=winbind -U ${DOMAIN_USERNAME}@${DIRECTORY_NAME} "$DIRECTORY_NAME" --computer-ou="$DIRECTORY_OU" -v 2>&1)
     fi
-    echo "########## SUCCESS: realm join successful $LOG_MSG ##########"
+    STATUS=$?
+    if [ $STATUS -eq 0 ]; then
+      break
+    else
+      if echo "$LOG_MSG" | grep -q "Already joined to this domain"; then
+        echo "do_domainjoin(): Already joined to this domain : $LOG_MSG"
+        STATUS=0
+        break
+      fi
+    fi
+    sleep 10
+  done
+
+  if [ $STATUS -ne 0 ]; then
+    echo "***Failed: realm join failed" && exit 1
+  fi
+  echo "########## SUCCESS: realm join successful $LOG_MSG ##########"
 }
 
 ##############################
 ## Configure nsswitch.conf  ##
 ##############################
 config_nsswitch() {
-    # Edit nsswitch config
-    NSSWITCH_CONF_FILE=/etc/nsswitch.conf
-    sed -i 's/^\s*passwd:.*$/passwd:     compat winbind/' $NSSWITCH_CONF_FILE
-    sed -i 's/^\s*group:.*$/group:      compat winbind/' $NSSWITCH_CONF_FILE
-    sed -i 's/^\s*shadow:.*$/shadow:     compat winbind/' $NSSWITCH_CONF_FILE
+  # Edit nsswitch config
+  NSSWITCH_CONF_FILE=/etc/nsswitch.conf
+  sed -i 's/^\s*passwd:.*$/passwd:     compat winbind/' $NSSWITCH_CONF_FILE
+  sed -i 's/^\s*group:.*$/group:      compat winbind/' $NSSWITCH_CONF_FILE
+  sed -i 's/^\s*shadow:.*$/shadow:     compat winbind/' $NSSWITCH_CONF_FILE
 }
 
 ###################################################
 ## Configure id-mappings in Samba                ##
 ###################################################
 config_samba() {
-    AD_INFO=$(adcli info ${DIRECTORY_NAME} | grep '^domain-short = ' | awk '{print $3}')
-    sed -i".pre-join" -r\
-        "/^\[global\]/a\\
+  AD_INFO=$(adcli info ${DIRECTORY_NAME} | grep '^domain-short = ' | awk '{print $3}')
+  sed -i".pre-join" -r "/^\[global\]/a\\
         idmap config * : backend = autorid\n\
         idmap config * : range = 100000000-2100000000\n\
         idmap config * : rangesize = 100000000\n\
@@ -691,27 +686,27 @@ config_samba() {
         /^\s*idmap/d;\
         /^\s*kerberos\s+method/d;\
         /^\s*winbind\s+refresh/d;\
-        /^\s*winbind\s+enum/d"\
-        /etc/samba/smb.conf
+        /^\s*winbind\s+enum/d" \
+    /etc/samba/smb.conf
 
-    cp /etc/samba/smb.conf /tmp
+  cp /etc/samba/smb.conf /tmp
 
-    # Flushing Samba Winbind databases
-    net cache flush
+  # Flushing Samba Winbind databases
+  net cache flush
 
-    # Restarting Winbind daemon
-    service winbind restart
+  # Restarting Winbind daemon
+  service winbind restart
 }
 
 reconfigure_samba() {
-    sed -i 's/kerberos method = system keytab/kerberos method = secrets and keytab/g' /etc/samba/smb.conf
-    service winbind restart
+  sed -i 's/kerberos method = system keytab/kerberos method = secrets and keytab/g' /etc/samba/smb.conf
+  service winbind restart
+  if [ $? -ne 0 ]; then
+    systemctl restart winbind
     if [ $? -ne 0 ]; then
-        systemctl restart winbind
-        if [ $? -ne 0 ]; then
-            service winbind restart
-        fi
+      service winbind restart
     fi
+  fi
 }
 
 ##################################################
@@ -720,103 +715,102 @@ reconfigure_samba() {
 CURTIME=$(date | sed 's/ //g')
 
 if [ $# -eq 0 ]; then
-    exit 1
+  exit 1
 fi
 
 for i in "$@"; do
-    case "$i" in
-        --directory-id)
-            shift
-            DIRECTORY_ID="$1"
-            continue
-            ;;
-        --directory-name)
-            shift;
-            DIRECTORY_NAME="$1"
-            continue
-            ;;
-        --directory-ou)
-            shift;
-            DIRECTORY_OU="$1"
-            continue
-            ;;
-        --instance-region)
-            shift;
-            REGION="$1"
-            continue
-            ;;
-        --dns-addresses)
-            shift;
-            DNS_ADDRESSES="$1"
-            DNS_IP_ADDRESS1=$(echo $DNS_ADDRESSES | awk -F',' '{ print $1 }')
-            DNS_IP_ADDRESS2=$(echo $DNS_ADDRESSES | awk -F',' '{ print $2 }')
-            continue
-            ;;
-        --proxy-address)
-            shift;
-            PROXY_ADDRESS="$1"
-            continue
-            ;;
-        --no-proxy)
-            shift;
-            NO_PROXY="$1"
-            continue
-            ;;
-        --set-hostname)
-            shift;
-            SET_HOSTNAME="$1"
-            continue
-            ;;
-        --set-hostname-append-num-digits)
-            shift;
-            SET_HOSTNAME_APPEND_NUM_DIGITS="$1"
-            continue
-            ;;
-    esac
-    shift
+  case "$i" in
+    --directory-id)
+      shift
+      DIRECTORY_ID="$1"
+      continue
+      ;;
+    --directory-name)
+      shift
+      DIRECTORY_NAME="$1"
+      continue
+      ;;
+    --directory-ou)
+      shift
+      DIRECTORY_OU="$1"
+      continue
+      ;;
+    --instance-region)
+      shift
+      REGION="$1"
+      continue
+      ;;
+    --dns-addresses)
+      shift
+      DNS_ADDRESSES="$1"
+      DNS_IP_ADDRESS1=$(echo $DNS_ADDRESSES | awk -F',' '{ print $1 }')
+      DNS_IP_ADDRESS2=$(echo $DNS_ADDRESSES | awk -F',' '{ print $2 }')
+      continue
+      ;;
+    --proxy-address)
+      shift
+      PROXY_ADDRESS="$1"
+      continue
+      ;;
+    --no-proxy)
+      shift
+      NO_PROXY="$1"
+      continue
+      ;;
+    --set-hostname)
+      shift
+      SET_HOSTNAME="$1"
+      continue
+      ;;
+    --set-hostname-append-num-digits)
+      shift
+      SET_HOSTNAME_APPEND_NUM_DIGITS="$1"
+      continue
+      ;;
+  esac
+  shift
 done
 
 if [ -z $REGION ]; then
-    echo "***Failed: No Region found" && exit 1
+  echo "***Failed: No Region found" && exit 1
 fi
 
 if [ ! -z $SET_HOSTNAME_APPEND_NUM_DIGITS ]; then
-    if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -le 0 -o \
-         $SET_HOSTNAME_APPEND_NUM_DIGITS -gt $MAX_APPEND_DIGITS ]; then
-           echo "**Failed: Invalid number of append digits $SET_HOSTNAME_APPEND_NUM_DIGITS"
-           exit 1
-    fi
+  if [ $SET_HOSTNAME_APPEND_NUM_DIGITS -le 0 -o \
+    $SET_HOSTNAME_APPEND_NUM_DIGITS -gt $MAX_APPEND_DIGITS ]; then
+    echo "**Failed: Invalid number of append digits $SET_HOSTNAME_APPEND_NUM_DIGITS"
+    exit 1
+  fi
 fi
 
 # Deal with scenario where this script is run again after the domain is already joined.
 # We want to avoid rerunning as the set_hostname function can change the hostname of a server that is already
 # domain joined and cause a mismatch.
-realm list 2>/dev/null | grep -q "domain-name: ${DIRECTORY_NAME}\$"
+realm list 2> /dev/null | grep -q "domain-name: ${DIRECTORY_NAME}\$"
 if [ $? -eq 0 ]; then
-    echo "########## SKIPPING Domain Join: ${DIRECTORY_NAME} already joined  ##########"
-    exit 0
+  echo "########## SKIPPING Domain Join: ${DIRECTORY_NAME} already joined  ##########"
+  exit 0
 fi
 
 REALM=$(echo "$DIRECTORY_NAME" | tr [a-z] [A-Z])
 
 MAX_RETRIES=8
-for i in $(seq 1 $MAX_RETRIES)
-do
-    echo "[$i] Attempt installing components"
-    install_components
-    if [ $? -eq 0 ]; then
-        break
-    fi
-    sleep 30
+for i in $(seq 1 $MAX_RETRIES); do
+  echo "[$i] Attempt installing components"
+  install_components
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  sleep 30
 done
 
 if [ -z $DNS_IP_ADDRESS1 ] && [ -z $DNS_IP_ADDRESS2 ]; then
-    DNS_ADDRESSES=$($AWSCLI ds describe-directories --region $REGION --directory-id $DIRECTORY_ID --output text | grep DNSIPADDR | awk '{print $2}')
-    if [ $? -ne 0 ]; then
-        echo "***Failed: DNS IPs not found" && exit 1
-    fi
-    DNS_IP_ADDRESS1=$(echo $DNS_ADDRESSES | awk '{ print $1 }')
-    DNS_IP_ADDRESS2=$(echo $DNS_ADDRESSES | awk '{ print $2 }')
+  DNS_ADDRESSES=$($AWSCLI ds describe-directories --region $REGION --directory-id $DIRECTORY_ID --output text | grep DNSIPADDR | awk '{print $2}')
+  if [ $? -ne 0 ]; then
+    echo "***Failed: DNS IPs not found" && exit 1
+  fi
+  DNS_IP_ADDRESS1=$(echo $DNS_ADDRESSES | awk '{ print $1 }')
+  DNS_IP_ADDRESS2=$(echo $DNS_ADDRESSES | awk '{ print $2 }')
 fi
 
 ## Configure DNS even if DHCP option set is used.
@@ -826,13 +820,13 @@ get_servicecreds
 COMPUTER_NAME=$(hostname --short)
 
 if [ ! -z $SET_HOSTNAME ]; then
-    find_unused_hostname "$SET_HOSTNAME"
-    if [ -z $COMPUTER_NAME ]; then
-        echo "**Failed: computername is empty"
-        exit 1
-    fi
+  find_unused_hostname "$SET_HOSTNAME"
+  if [ -z $COMPUTER_NAME ]; then
+    echo "**Failed: computername is empty"
+    exit 1
+  fi
 else
-    get_default_hostname
+  get_default_hostname
 fi
 
 set_hostname
@@ -841,25 +835,25 @@ configure_hosts_file
 sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 systemctl restart sshd
 if [ $? -ne 0 ]; then
-   systemctl restart ssh
-   if [ $? -ne 0 ]; then
-      service sshd restart
-   fi
-   if [ $? -ne 0 ]; then
-      service ssh restart
-   fi
+  systemctl restart ssh
+  if [ $? -ne 0 ]; then
+    service sshd restart
+  fi
+  if [ $? -ne 0 ]; then
+    service ssh restart
+  fi
 fi
 
 print_vars
 is_directory_reachable
 if [ $? -eq 0 ]; then
-    config_nsswitch
-    config_samba
-    do_domainjoin
-    reconfigure_samba
+  config_nsswitch
+  config_samba
+  do_domainjoin
+  reconfigure_samba
 else
-    echo "**Failed: Unable to reach DNS server"
-    exit 1
+  echo "**Failed: Unable to reach DNS server"
+  exit 1
 fi
 
 echo "Success"

--- a/n_utils/includes/aws_tools.sh
+++ b/n_utils/includes/aws_tools.sh
@@ -19,12 +19,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/common_tools.sh"
 # Optional parameters in CloudFormation stack: paramEipAllocationId OR paramEip
 # Required template policies when CF_paramEipAllocationId is used: ec2:AssociateAddress
 # Required template policies when CF_paramEip is used: ec2:AssociateAddress, ec2:DescribeAddresses
-aws_ec2_associate_address () {
+aws_ec2_associate_address() {
   ndt associate-eip
 }
 
 # Required parameters in CloudFormation: CF_AWS__Region, CF_AWS__StackName
-aws_install_metadata_files () {
+aws_install_metadata_files() {
   [ "$CF_AWS__StackName" ] || CF_AWS__StackName="$(ndt cf-stack-name)"
   [ "$CF_AWS__Region" ] || CF_AWS__Region="$(ndt cf-region)"
   RESOURCE="$(ndt ec2-get-tag 'ndt:cfinit:resource' || echo '')"

--- a/n_utils/includes/bake-docker.sh
+++ b/n_utils/includes/bake-docker.sh
@@ -46,8 +46,8 @@ usage() {
   echo "              you would give cluster" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -h, --help  show this help message and exit"  >&2
-  echo "  -i, --imagedefinitions  create imagedefinitions.json for AWS CodePipeline"  >&2
+  echo "  -h, --help  show this help message and exit" >&2
+  echo "  -i, --imagedefinitions  create imagedefinitions.json for AWS CodePipeline" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -58,7 +58,7 @@ if [ "$1" = "--help" -o "$1" = "-h" ]; then
   usage
 fi
 
-die () {
+die() {
   usage
 }
 set -xe
@@ -68,9 +68,11 @@ if [ "$1" = "--imagedefinitions" -o "$1" = "-i" ]; then
   OUTPUT_DEFINITION=1
 fi
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-docker="$1"; shift
+docker="$1"
+shift
 [ "${docker}" ] || die "You must give the docker name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)
@@ -101,13 +103,13 @@ fi
 
 eval "$(ndt session-to-env)"
 if [ -z "$NO_PULL" ]; then
-   PULL="--pull"
+  PULL="--pull"
 fi
 
 eval "$(ndt ecr-ensure-repo "$DOCKER_NAME")"
 if [ -z "$PLATFORM" ]; then
   PLATFORM="linux/amd64"
-  docker build $PULL --tag "$DOCKER_NAME" --build-arg "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"  --build-arg "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" --build-arg "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" "$component/docker-$ORIG_DOCKER_NAME"
+  docker build $PULL --tag "$DOCKER_NAME" --build-arg "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" --build-arg "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" --build-arg "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" "$component/docker-$ORIG_DOCKER_NAME"
 
   docker tag $DOCKER_NAME:latest $DOCKER_NAME:$BUILD_NUMBER
   docker tag $DOCKER_NAME:latest $REPO:latest
@@ -122,7 +124,7 @@ else
       "./pre_build_${N_PLATFORM_SAFE}.sh"
       cd ../..
     fi
-    docker buildx build $PULL --tag "${DOCKER_NAME}:${N_PLATFORM_SAFE}" --platform $N_PLATFORM --build-arg "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"  --build-arg "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" --build-arg "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" "$component/docker-$ORIG_DOCKER_NAME"
+    docker buildx build $PULL --tag "${DOCKER_NAME}:${N_PLATFORM_SAFE}" --platform $N_PLATFORM --build-arg "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" --build-arg "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" --build-arg "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" "$component/docker-$ORIG_DOCKER_NAME"
     docker tag "${DOCKER_NAME}:${N_PLATFORM_SAFE}" $REPO:${BUILD_NUMBER}-${N_PLATFORM_SAFE}
     docker push $REPO:${BUILD_NUMBER}-${N_PLATFORM_SAFE}
   done

--- a/n_utils/includes/bake-image.sh
+++ b/n_utils/includes/bake-image.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 if [ "$_ARGCOMPLETE" ]; then
   # Handle command completion executions
   unset _ARGCOMPLETE
@@ -32,7 +31,6 @@ if [ "$_ARGCOMPLETE" ]; then
   esac
   exit 0
 fi
-
 
 usage() {
   echo "usage: ndt bake-image [-h] component [image-name]" >&2
@@ -57,12 +55,13 @@ if [ "$1" = "--help" -o "$1" = "-h" ]; then
   usage
 fi
 
-die () {
+die() {
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
 
 export AWS_PAGER=""
@@ -114,7 +113,7 @@ if ! [ "$AMIBAKE_INSTANCEPROFILE" ]; then
   AMIBAKE_INSTANCEPROFILE="$(ndt show-stack-params-and-outputs -r $REGION $BAKERY_ROLES_STACK -p $INSTANCE_PROFILE_PARAM)"
 fi
 [ "$PAUSE_SECONDS" ] || PAUSE_SECONDS=15
-for var in REGION SUBNET SECURITY_GROUP AMIBAKE_INSTANCEPROFILE ; do
+for var in REGION SUBNET SECURITY_GROUP AMIBAKE_INSTANCEPROFILE; do
   [ "${!var}" ] || die "Could not determine $var automatically. Please set ${var} manually in ${infrapropfile}"
 done
 
@@ -169,9 +168,9 @@ trap cleanup EXIT
 if [ "$IMAGETYPE" != "windows" ]; then
   eval $(ssh-agent)
   if ! [ -e $HOME/.ssh/$AWS_KEY_NAME -o -e $HOME/.ssh/$AWS_KEY_NAME.pem \
-         -o -e $HOME/.ssh/$AWS_KEY_NAME.rsa ]; then
+    -o -e $HOME/.ssh/$AWS_KEY_NAME.rsa ]; then
     fetch-secrets.sh get 600 --optional "$HOME/.ssh/$AWS_KEY_NAME" \
-        "$HOME/.ssh/$AWS_KEY_NAME.pem" "$HOME/.ssh/$AWS_KEY_NAME.rsa" ||:
+      "$HOME/.ssh/$AWS_KEY_NAME.pem" "$HOME/.ssh/$AWS_KEY_NAME.rsa" || :
   fi
   if [ -r "$HOME/.ssh/$AWS_KEY_NAME" ]; then
     ssh-add "$HOME/.ssh/$AWS_KEY_NAME"
@@ -288,7 +287,7 @@ if [ "$IMAGETYPE" = "windows" ]; then
 else
   PLAYBOOK="$(n-include bake-image.yml)"
 fi
-rm -f ami.properties ||:
+rm -f ami.properties || :
 cat > ansible.cfg << MARKER
 [defaults]
 retry_files_enabled = False
@@ -335,7 +334,7 @@ fi
 
 if [ -n "${SHARE_REGIONS}" ]; then
   echo "--------------------- Share to ${SHARE_REGIONS}"
-  for region in ${SHARE_REGIONS//,/ } ; do
+  for region in ${SHARE_REGIONS//,/ }; do
     var_region_accounts=REGION_${region//-/_}_ACCOUNTS
     if [ ! "${!var_region_accounts}" ]; then
       echo "Missing setting '${var_region_accounts}' in ${infrapropfile}"

--- a/n_utils/includes/cloud_init_functions.sh
+++ b/n_utils/includes/cloud_init_functions.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 set -e
-: <<'EOF'
+: << 'EOF'
 
 For required parameters, see end of this script.
 
@@ -48,7 +48,7 @@ Required template policies - please update all the Ref resource names as necessa
       - {Ref: roleResource}
 EOF
 
-onexit () {
+onexit() {
   echo -----------------------------------------------------------------
   set +e
   if which fetch-secrets.sh &> /dev/null 2>&1; then

--- a/n_utils/includes/common_tools.sh
+++ b/n_utils/includes/common_tools.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-check_parameters () {
+check_parameters() {
   fail=0
-  for param ; do
-    if ! eval echo \"\$\{"${param}"\}\" | grep -q . ; then
+  for param; do
+    if ! eval echo \"\$\{"${param}"\}\" | grep -q .; then
       echo "Missing parameter: $param"
       fail=1
     fi
@@ -28,16 +28,22 @@ check_parameters () {
 }
 
 system_type() {
-  (source /etc/os-release; echo $ID)
+  (
+    source /etc/os-release
+    echo $ID
+  )
 }
 
 system_like() {
   source /etc/os-release
-  [[ "$ID_LIKE"  =~ $1 ]]
+  [[ "$ID_LIKE" =~ $1 ]]
 }
 
 system_type_and_version() {
-  (source /etc/os-release; echo ${ID}_$VERSION_ID)
+  (
+    source /etc/os-release
+    echo ${ID}_$VERSION_ID
+  )
 }
 
 set_timezone() {
@@ -48,10 +54,11 @@ set_timezone() {
   ln -snf ../usr/share/zoneinfo/$tz /etc/localtime
   [ ! -e /etc/timezone ] || echo $tz > /etc/timezone
 }
+
 # Set aws-cli region to the region of the current instance
 set_region() {
   [ "${REGION}" -o ! "${CF_AWS__Region}" ] || REGION="${CF_AWS__Region}"
-  [ "${REGION}" ] || REGION=$(curl -s --connect-timeout 3 http://169.254.169.254/latest/dynamic/instance-identity/document|grep region|awk -F\" '{print $4}')
+  [ "${REGION}" ] || REGION=$(curl -s --connect-timeout 3 http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
   aws configure set default.region $REGION
 }
 
@@ -61,6 +68,7 @@ set_hostname() {
     echo "${CF_paramDnsName}" > /etc/hostname
   fi
 }
+
 allow_cloud_init_firewall_cmd() {
   local SOURCE=$(n-include cloud-init-firewall-cmd.te)
   local BASE=${SOURCE%.te}
@@ -70,6 +78,7 @@ allow_cloud_init_firewall_cmd() {
   semodule_package -o $PACKAGE -m $MODULE
   semodule -i $PACKAGE
 }
+
 allow_authorizedkeyscommand() {
   if system_like rhel; then
     yum update -y selinux-policy*
@@ -84,6 +93,7 @@ allow_authorizedkeyscommand() {
   semodule_package -o $PACKAGE -m $MODULE
   semodule -i $PACKAGE
 }
+
 safe_download() {
   url="$1"
   csum="$2"
@@ -92,20 +102,22 @@ safe_download() {
   wget --no-verbose --output-document="$out" "$url"
   echo "$csum  $out" | sha256sum --check
 }
+
 wait_background_jobs() {
   for i in $(jobs -p); do
     wait $i
   done
 }
-function add_gpg_key() {
+
+add_gpg_key() {
   local key=$1
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key"
+  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ||
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ||
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key"
 }
 
-function gpg_safe_download() {
+gpg_safe_download() {
   local URL=$1
   local DST=$2
   local SIG_SUFFIX=${3:-sig}
@@ -118,4 +130,5 @@ function gpg_safe_download() {
   fi
   gpg --verify $DST.sig $DST
 }
+
 SYSTEM_TYPE=$(system_type)

--- a/n_utils/includes/creatable-templates/jenkins/post_install.sh
+++ b/n_utils/includes/creatable-templates/jenkins/post_install.sh
@@ -26,17 +26,17 @@ done
 set +x
 ADMIN_AUTH=$(cat /var/lib/jenkins/secrets/initialAdminPassword)
 for PLUGIN in ansicolor cron_column extensible-choice-parameter extra-columns git \
- git-client git-server greenballs job-dsl mailer next-build-number parameterized-trigger \
- pipeline-input-step progress-bar-column-plugin rebuild script-security simple-theme-plugin; do
-   java -jar jenkins-cli.jar -s http://localhost:8080/ -auth "admin:$ADMIN_AUTH" install-plugin $PLUGIN -deploy
+  git-client git-server greenballs job-dsl mailer next-build-number parameterized-trigger \
+  pipeline-input-step progress-bar-column-plugin rebuild script-security simple-theme-plugin; do
+  java -jar jenkins-cli.jar -s http://localhost:8080/ -auth "admin:$ADMIN_AUTH" install-plugin $PLUGIN -deploy
 done
 set -x
 systemctl disable jenkins
 systemctl disable httpd
-systemctl disable docker ||:
-systemctl stop jenkins ||:
-systemctl stop httpd ||:
-systemctl stop docker ||:
+systemctl disable docker || :
+systemctl stop jenkins || :
+systemctl stop httpd || :
+systemctl stop docker || :
 
 groupadd -aG docker jenkins
 

--- a/n_utils/includes/creatable-templates/jenkins/userdata.sh
+++ b/n_utils/includes/creatable-templates/jenkins/userdata.sh
@@ -30,9 +30,9 @@ source $(n-include ssh_tools.sh)
 source $(n-include apache_tools.sh)
 source $(n-include ssh_tools.sh)
 
-fail () {
-    echo "FAIL: $@"
-    exit 1
+fail() {
+  echo "FAIL: $@"
+  exit 1
 }
 usermod -s /bin/bash jenkins
 set_region

--- a/n_utils/includes/deploy-azure.sh
+++ b/n_utils/includes/deploy-azure.sh
@@ -50,9 +50,9 @@ usage() {
   echo "                  you would give blobstore" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and azure cli what-if operation"  >&2
-  echo "  -v, --verbose verbose - verbose output from azure cli"  >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and azure cli what-if operation" >&2
+  echo "  -v, --verbose verbose - verbose output from azure cli" >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -71,16 +71,18 @@ while [ "$1" = "-d" -o "$1" = "--dryrun" -o "$1" = "-v" -o "$1" = "--verbose" ];
     shift
   fi
 done
-die () {
+die() {
   set +x
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-azure="$1"; shift
+azure="$1"
+shift
 [ "${azure}" ] || die "You must give the azure name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)
@@ -155,7 +157,7 @@ fi
 
 set -e
 az $VERBOSE deployment $SCOPE_COMMAND create \
-  --name $DEPLOYMENT_NAME  \
+  --name $DEPLOYMENT_NAME \
   $GROUP_ARGS \
   $WHATIF_ARG \
   --template-file azuredeploy.$TEMPLATE_TYPE \

--- a/n_utils/includes/deploy-cdk.sh
+++ b/n_utils/includes/deploy-cdk.sh
@@ -50,8 +50,8 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -d, --dryrun  dry-run - do only parameter expansion and pre_deploy.sh and cdk diff"  >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -d, --dryrun  dry-run - do only parameter expansion and pre_deploy.sh and cdk diff" >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -65,15 +65,17 @@ if [ "$1" = "-d" -o "$1" = "--dryrun" ]; then
   DRYRUN=1
   shift
 fi
-die () {
+die() {
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-cdk="$1"; shift
+cdk="$1"
+shift
 [ "${cdk}" ] || die "You must give the cdk name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)
@@ -101,7 +103,7 @@ if [ -x "./pre_deploy.sh" ]; then
 fi
 
 cdk synth
-cdk diff ||:
+cdk diff || :
 
 if [ -n "$DRYRUN" ]; then
   echo "Dry run - quitting"

--- a/n_utils/includes/deploy-serverless.sh
+++ b/n_utils/includes/deploy-serverless.sh
@@ -50,9 +50,9 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and npm ci"  >&2
-  echo "  -v, --verbose verbose - verbose output from serverless framework"  >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and npm ci" >&2
+  echo "  -v, --verbose verbose - verbose output from serverless framework" >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -71,15 +71,17 @@ while [ "$1" = "-d" -o "$1" = "--dryrun" -o "$1" = "-v" -o "$1" = "--verbose" ];
     shift
   fi
 done
-die () {
+die() {
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-serverless="$1"; shift
+serverless="$1"
+shift
 [ "${serverless}" ] || die "You must give the serverless name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)

--- a/n_utils/includes/deploy-stack.sh
+++ b/n_utils/includes/deploy-stack.sh
@@ -18,7 +18,7 @@ if [ "$_ARGCOMPLETE" ]; then
   unset _ARGCOMPLETE
   source $(n-include autocomplete-helpers.sh)
   # Handle command completion executions
-  COMP_WORDS=( $COMP_LINE )
+  COMP_WORDS=($COMP_LINE)
   if [ "${COMP_WORDS[2]}" = "-d" ]; then
     COMP_INDEX=$(($COMP_CWORD - 1))
     IMAGE_DIR=${COMP_WORDS[3]}
@@ -28,7 +28,7 @@ if [ "$_ARGCOMPLETE" ]; then
     IMAGE_DIR=${COMP_WORDS[2]}
     STACK=${COMP_WORDS[3]}
   fi
-  IMAGE=$(echo $IMAGE_DIR| tr "-" "_")
+  IMAGE=$(echo $IMAGE_DIR | tr "-" "_")
   case $COMP_INDEX in
     2)
       if [ "$COMP_INDEX" = "$COMP_CWORD" ]; then
@@ -89,18 +89,18 @@ POSITIONAL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    -d|--dryrun)
+    -d | --dryrun)
       DRY_RUN="--dry-run"
       shift
       ;;
-    -r|--disable-rollback)
+    -r | --disable-rollback)
       DISABLE_ROLLBACK="--disable-rollback"
       shift
       ;;
-    -h|--help)
+    -h | --help)
       usage
       ;;
-    -*|--*)
+    -* | --*)
       echo "Unknown option $1"
       usage
       ;;
@@ -112,12 +112,14 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 set -xe
-component="$1" ; shift
-stackName="$1" ; shift
+component="$1"
+shift
+stackName="$1"
+shift
 ARG_AMI_ID="$1"
-shift ||:
+shift || :
 ARG_IMAGE_JOB="$1"
-shift ||:
+shift || :
 
 if [ -n "$ARG_AMI_ID" ]; then
   export AMI_ID=$ARG_AMI_ID paramAmi=$ARG_AMI_ID

--- a/n_utils/includes/deploy-terraform.sh
+++ b/n_utils/includes/deploy-terraform.sh
@@ -52,8 +52,8 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing"  >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing" >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -67,15 +67,17 @@ if [ "$1" = "-d" -o "$1" = "--dryrun" ]; then
   DRYRUN=1
   shift
 fi
-die () {
+die() {
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-terraform="$1"; shift
+terraform="$1"
+shift
 [ "${terraform}" ] || die "You must give the terraform name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)

--- a/n_utils/includes/fetch-secrets-lpass.sh
+++ b/n_utils/includes/fetch-secrets-lpass.sh
@@ -17,7 +17,7 @@
 [ "$CF_paramSecretsBucket" ] || CF_paramSecretsBucket="$(ndt cf-get-parameter paramSecretsBucket)"
 [ "$CF_paramSecretsUser" ] || CF_paramSecretsUser="$(ndt cf-get-parameter paramSecretsUser)"
 
-login_if_not_already () {
+login_if_not_already() {
   if ! lpass ls not-meant-to-return-anything > /dev/null 2>&1; then
     export AWS_DEFAULT_REGION=$(ndt ec2-region)
     aws s3 cp s3://${CF_paramSecretsBucket}/webmaster.pwd - | $(n-include lastpass-login.sh) ${CF_paramSecretsUser} - > /dev/null 2>&1

--- a/n_utils/includes/fetch-secrets-s3.sh
+++ b/n_utils/includes/fetch-secrets-s3.sh
@@ -27,7 +27,7 @@ case "$COMMAND" in
   show)
     SHOW=1
     ;;
-  login|logout)
+  login | logout)
     exit 0
     ;;
   *)

--- a/n_utils/includes/fetch-secrets-vault.sh
+++ b/n_utils/includes/fetch-secrets-vault.sh
@@ -17,7 +17,7 @@
 mode="444"
 
 fetch() {
-  for path ; do
+  for path; do
     if [ "$path" = "--optional" ]; then
       optional=1
       continue
@@ -26,14 +26,14 @@ fetch() {
     DNAME="$(dirname "$path")"
     mkdir -p "$DNAME"
     if [ -e "$path" ]; then
-        TMPDIR=$(mktemp -d $path.XXXXXXX)
-        mv "$path" "$TMPDIR/"
+      TMPDIR=$(mktemp -d $path.XXXXXXX)
+      mv "$path" "$TMPDIR/"
     fi
     if ! vault -l "$FNAME" > "$path"; then
       rm -f "$path"
       if [ -n "$TMPDIR" ]; then
-          mv "$TMPDIR/$FNAME" "$path"
-          rm -rf "$TMPDIR"
+        mv "$TMPDIR/$FNAME" "$path"
+        rm -rf "$TMPDIR"
       fi
       if [ ! "$optional" ]; then
         echo "ERROR: Failed to get file $path"

--- a/n_utils/includes/get-docker.sh
+++ b/n_utils/includes/get-docker.sh
@@ -31,48 +31,48 @@ VERSION="${VERSION#v}"
 #   * edge (deprecated)
 DEFAULT_CHANNEL_VALUE="stable"
 if [ -z "$CHANNEL" ]; then
-	CHANNEL=$DEFAULT_CHANNEL_VALUE
+  CHANNEL=$DEFAULT_CHANNEL_VALUE
 fi
 
 DEFAULT_DOWNLOAD_URL="https://download.docker.com"
 if [ -z "$DOWNLOAD_URL" ]; then
-	DOWNLOAD_URL=$DEFAULT_DOWNLOAD_URL
+  DOWNLOAD_URL=$DEFAULT_DOWNLOAD_URL
 fi
 
 DEFAULT_REPO_FILE="docker-ce.repo"
 if [ -z "$REPO_FILE" ]; then
-	REPO_FILE="$DEFAULT_REPO_FILE"
+  REPO_FILE="$DEFAULT_REPO_FILE"
 fi
 
 mirror=''
 DRY_RUN=${DRY_RUN:-}
 while [ $# -gt 0 ]; do
-	case "$1" in
-		--mirror)
-			mirror="$2"
-			shift
-			;;
-		--dry-run)
-			DRY_RUN=1
-			;;
-		--*)
-			echo "Illegal option $1"
-			;;
-	esac
-	shift $(( $# > 0 ? 1 : 0 ))
+  case "$1" in
+    --mirror)
+      mirror="$2"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --*)
+      echo "Illegal option $1"
+      ;;
+  esac
+  shift $(($# > 0 ? 1 : 0))
 done
 
 case "$mirror" in
-	Aliyun)
-		DOWNLOAD_URL="https://mirrors.aliyun.com/docker-ce"
-		;;
-	AzureChinaCloud)
-		DOWNLOAD_URL="https://mirror.azure.cn/docker-ce"
-		;;
+  Aliyun)
+    DOWNLOAD_URL="https://mirrors.aliyun.com/docker-ce"
+    ;;
+  AzureChinaCloud)
+    DOWNLOAD_URL="https://mirror.azure.cn/docker-ce"
+    ;;
 esac
 
 command_exists() {
-	command -v "$@" > /dev/null 2>&1
+  command -v "$@" > /dev/null 2>&1
 }
 
 # version_gte checks if the version specified in $VERSION is at least
@@ -87,10 +87,10 @@ command_exists() {
 # version_gte 19.03 // 0 (success)
 # version_gte 21.10 // 1 (fail)
 version_gte() {
-	if [ -z "$VERSION" ]; then
-			return 0
-	fi
-	eval calver_compare "$VERSION" "$1"
+  if [ -z "$VERSION" ]; then
+    return 0
+  fi
+  eval calver_compare "$VERSION" "$1"
 }
 
 # calver_compare compares two CalVer (YY.MM) version strings. returns 0 (success)
@@ -103,170 +103,170 @@ version_gte() {
 # calver_compare 20.10 20.10 // 0 (success)
 # calver_compare 19.03 20.10 // 1 (fail)
 calver_compare() (
-	set +x
+  set +x
 
-	yy_a="$(echo "$1" | cut -d'.' -f1)"
-	yy_b="$(echo "$2" | cut -d'.' -f1)"
-	if [ "$yy_a" -lt "$yy_b" ]; then
-		return 1
-	fi
-	if [ "$yy_a" -gt "$yy_b" ]; then
-		return 0
-	fi
-	mm_a="$(echo "$1" | cut -d'.' -f2)"
-	mm_b="$(echo "$2" | cut -d'.' -f2)"
-	if [ "${mm_a#0}" -lt "${mm_b#0}" ]; then
-		return 1
-	fi
+  yy_a="$(echo "$1" | cut -d'.' -f1)"
+  yy_b="$(echo "$2" | cut -d'.' -f1)"
+  if [ "$yy_a" -lt "$yy_b" ]; then
+    return 1
+  fi
+  if [ "$yy_a" -gt "$yy_b" ]; then
+    return 0
+  fi
+  mm_a="$(echo "$1" | cut -d'.' -f2)"
+  mm_b="$(echo "$2" | cut -d'.' -f2)"
+  if [ "${mm_a#0}" -lt "${mm_b#0}" ]; then
+    return 1
+  fi
 
-	return 0
+  return 0
 )
 
 is_dry_run() {
-	if [ -z "$DRY_RUN" ]; then
-		return 1
-	else
-		return 0
-	fi
+  if [ -z "$DRY_RUN" ]; then
+    return 1
+  else
+    return 0
+  fi
 }
 
 is_wsl() {
-	case "$(uname -r)" in
-	*microsoft* ) true ;; # WSL 2
-	*Microsoft* ) true ;; # WSL 1
-	* ) false;;
-	esac
+  case "$(uname -r)" in
+    *microsoft*) true ;; # WSL 2
+    *Microsoft*) true ;; # WSL 1
+    *) false ;;
+  esac
 }
 
 is_darwin() {
-	case "$(uname -s)" in
-	*darwin* ) true ;;
-	*Darwin* ) true ;;
-	* ) false;;
-	esac
+  case "$(uname -s)" in
+    *darwin*) true ;;
+    *Darwin*) true ;;
+    *) false ;;
+  esac
 }
 
 deprecation_notice() {
-	distro=$1
-	distro_version=$2
-	echo
-	printf "\033[91;1mDEPRECATION WARNING\033[0m\n"
-	printf "    This Linux distribution (\033[1m%s %s\033[0m) reached end-of-life and is no longer supported by this script.\n" "$distro" "$distro_version"
-	echo   "    No updates or security fixes will be released for this distribution, and users are recommended"
-	echo   "    to upgrade to a currently maintained version of $distro."
-	echo
-	printf   "Press \033[1mCtrl+C\033[0m now to abort this script, or wait for the installation to continue."
-	echo
-	sleep 10
+  distro=$1
+  distro_version=$2
+  echo
+  printf "\033[91;1mDEPRECATION WARNING\033[0m\n"
+  printf "    This Linux distribution (\033[1m%s %s\033[0m) reached end-of-life and is no longer supported by this script.\n" "$distro" "$distro_version"
+  echo "    No updates or security fixes will be released for this distribution, and users are recommended"
+  echo "    to upgrade to a currently maintained version of $distro."
+  echo
+  printf "Press \033[1mCtrl+C\033[0m now to abort this script, or wait for the installation to continue."
+  echo
+  sleep 10
 }
 
 get_distribution() {
-	lsb_dist=""
-	# Every system that we officially support has /etc/os-release
-	if [ -r /etc/os-release ]; then
-		lsb_dist="$(. /etc/os-release && echo "$ID")"
-	fi
-	# Returning an empty string here should be alright since the
-	# case statements don't act unless you provide an actual value
-	echo "$lsb_dist"
+  lsb_dist=""
+  # Every system that we officially support has /etc/os-release
+  if [ -r /etc/os-release ]; then
+    lsb_dist="$(. /etc/os-release && echo "$ID")"
+  fi
+  # Returning an empty string here should be alright since the
+  # case statements don't act unless you provide an actual value
+  echo "$lsb_dist"
 }
 
 echo_docker_as_nonroot() {
-	if is_dry_run; then
-		return
-	fi
-	if command_exists docker && [ -e /var/run/docker.sock ]; then
-		(
-			set -x
-			$sh_c 'docker version'
-		) || true
-	fi
+  if is_dry_run; then
+    return
+  fi
+  if command_exists docker && [ -e /var/run/docker.sock ]; then
+    (
+      set -x
+      $sh_c 'docker version'
+    ) || true
+  fi
 
-	# intentionally mixed spaces and tabs here -- tabs are stripped by "<<-EOF", spaces are kept in the output
-	echo
-	echo "================================================================================"
-	echo
-	if version_gte "20.10"; then
-		echo "To run Docker as a non-privileged user, consider setting up the"
-		echo "Docker daemon in rootless mode for your user:"
-		echo
-		echo "    dockerd-rootless-setuptool.sh install"
-		echo
-		echo "Visit https://docs.docker.com/go/rootless/ to learn about rootless mode."
-		echo
-	fi
-	echo
-	echo "To run the Docker daemon as a fully privileged service, but granting non-root"
-	echo "users access, refer to https://docs.docker.com/go/daemon-access/"
-	echo
-	echo "WARNING: Access to the remote API on a privileged Docker daemon is equivalent"
-	echo "         to root access on the host. Refer to the 'Docker daemon attack surface'"
-	echo "         documentation for details: https://docs.docker.com/go/attack-surface/"
-	echo
-	echo "================================================================================"
-	echo
+  # intentionally mixed spaces and tabs here -- tabs are stripped by "<<-EOF", spaces are kept in the output
+  echo
+  echo "================================================================================"
+  echo
+  if version_gte "20.10"; then
+    echo "To run Docker as a non-privileged user, consider setting up the"
+    echo "Docker daemon in rootless mode for your user:"
+    echo
+    echo "    dockerd-rootless-setuptool.sh install"
+    echo
+    echo "Visit https://docs.docker.com/go/rootless/ to learn about rootless mode."
+    echo
+  fi
+  echo
+  echo "To run the Docker daemon as a fully privileged service, but granting non-root"
+  echo "users access, refer to https://docs.docker.com/go/daemon-access/"
+  echo
+  echo "WARNING: Access to the remote API on a privileged Docker daemon is equivalent"
+  echo "         to root access on the host. Refer to the 'Docker daemon attack surface'"
+  echo "         documentation for details: https://docs.docker.com/go/attack-surface/"
+  echo
+  echo "================================================================================"
+  echo
 }
 
 # Check if this is a forked Linux distro
 check_forked() {
 
-	# Check for lsb_release command existence, it usually exists in forked distros
-	if command_exists lsb_release; then
-		# Check if the `-u` option is supported
-		set +e
-		lsb_release -a -u > /dev/null 2>&1
-		lsb_release_exit_code=$?
-		set -e
+  # Check for lsb_release command existence, it usually exists in forked distros
+  if command_exists lsb_release; then
+    # Check if the `-u` option is supported
+    set +e
+    lsb_release -a -u > /dev/null 2>&1
+    lsb_release_exit_code=$?
+    set -e
 
-		# Check if the command has exited successfully, it means we're in a forked distro
-		if [ "$lsb_release_exit_code" = "0" ]; then
-			# Print info about current distro
-			cat <<-EOF
-			You're using '$lsb_dist' version '$dist_version'.
+    # Check if the command has exited successfully, it means we're in a forked distro
+    if [ "$lsb_release_exit_code" = "0" ]; then
+      # Print info about current distro
+      cat <<- EOF
+				You're using '$lsb_dist' version '$dist_version'.
 			EOF
 
-			# Get the upstream release info
-			lsb_dist=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'id' | cut -d ':' -f 2 | tr -d '[:space:]')
-			dist_version=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'codename' | cut -d ':' -f 2 | tr -d '[:space:]')
+      # Get the upstream release info
+      lsb_dist=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'id' | cut -d ':' -f 2 | tr -d '[:space:]')
+      dist_version=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'codename' | cut -d ':' -f 2 | tr -d '[:space:]')
 
-			# Print info about upstream distro
-			cat <<-EOF
-			Upstream release is '$lsb_dist' version '$dist_version'.
+      # Print info about upstream distro
+      cat <<- EOF
+				Upstream release is '$lsb_dist' version '$dist_version'.
 			EOF
-		else
-			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ] && [ "$lsb_dist" != "raspbian" ]; then
-				if [ "$lsb_dist" = "osmc" ]; then
-					# OSMC runs Raspbian
-					lsb_dist=raspbian
-				else
-					# We're Debian and don't even know it!
-					lsb_dist=debian
-				fi
-				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
-				case "$dist_version" in
-					11)
-						dist_version="bullseye"
-					;;
-					10)
-						dist_version="buster"
-					;;
-					9)
-						dist_version="stretch"
-					;;
-					8)
-						dist_version="jessie"
-					;;
-				esac
-			fi
-		fi
-	fi
+    else
+      if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ] && [ "$lsb_dist" != "raspbian" ]; then
+        if [ "$lsb_dist" = "osmc" ]; then
+          # OSMC runs Raspbian
+          lsb_dist=raspbian
+        else
+          # We're Debian and don't even know it!
+          lsb_dist=debian
+        fi
+        dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
+        case "$dist_version" in
+          11)
+            dist_version="bullseye"
+            ;;
+          10)
+            dist_version="buster"
+            ;;
+          9)
+            dist_version="stretch"
+            ;;
+          8)
+            dist_version="jessie"
+            ;;
+        esac
+      fi
+    fi
+  fi
 }
 
 do_install() {
-	echo "# Executing docker install script, commit: $SCRIPT_COMMIT_SHA"
+  echo "# Executing docker install script, commit: $SCRIPT_COMMIT_SHA"
 
-	if command_exists docker; then
-		cat >&2 <<-'EOF'
+  if command_exists docker; then
+    cat >&2 <<- 'EOF'
 			Warning: the "docker" command appears to already exist on this system.
 
 			If you already have Docker installed, this script can cause trouble, which is
@@ -278,353 +278,362 @@ do_install() {
 
 			You may press Ctrl+C now to abort this script.
 		EOF
-		( set -x; sleep 20 )
-	fi
+    (
+      set -x
+      sleep 20
+    )
+  fi
 
-	user="$(id -un 2>/dev/null || true)"
+  user="$(id -un 2> /dev/null || true)"
 
-	sh_c='sh -c'
-	if [ "$user" != 'root' ]; then
-		if command_exists sudo; then
-			sh_c='sudo -E sh -c'
-		elif command_exists su; then
-			sh_c='su -c'
-		else
-			cat >&2 <<-'EOF'
-			Error: this installer needs the ability to run commands as root.
-			We are unable to find either "sudo" or "su" available to make this happen.
+  sh_c='sh -c'
+  if [ "$user" != 'root' ]; then
+    if command_exists sudo; then
+      sh_c='sudo -E sh -c'
+    elif command_exists su; then
+      sh_c='su -c'
+    else
+      cat >&2 <<- 'EOF'
+				Error: this installer needs the ability to run commands as root.
+				We are unable to find either "sudo" or "su" available to make this happen.
 			EOF
-			exit 1
-		fi
-	fi
+      exit 1
+    fi
+  fi
 
-	if is_dry_run; then
-		sh_c="echo"
-	fi
+  if is_dry_run; then
+    sh_c="echo"
+  fi
 
-	# perform some very rudimentary platform detection
-	lsb_dist=$( get_distribution )
-	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+  # perform some very rudimentary platform detection
+  lsb_dist=$(get_distribution)
+  lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
 
-	if is_wsl; then
-		echo
-		echo "WSL DETECTED: We recommend using Docker Desktop for Windows."
-		echo "Please get Docker Desktop from https://www.docker.com/products/docker-desktop"
-		echo
-		cat >&2 <<-'EOF'
+  if is_wsl; then
+    echo
+    echo "WSL DETECTED: We recommend using Docker Desktop for Windows."
+    echo "Please get Docker Desktop from https://www.docker.com/products/docker-desktop"
+    echo
+    cat >&2 <<- 'EOF'
 
 			You may press Ctrl+C now to abort this script.
 		EOF
-		( set -x; sleep 20 )
-	fi
+    (
+      set -x
+      sleep 20
+    )
+  fi
 
-	case "$lsb_dist" in
+  case "$lsb_dist" in
 
-		ubuntu)
-			if command_exists lsb_release; then
-				dist_version="$(lsb_release --codename | cut -f2)"
-			fi
-			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
-				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
-			fi
-		;;
+    ubuntu)
+      if command_exists lsb_release; then
+        dist_version="$(lsb_release --codename | cut -f2)"
+      fi
+      if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
+        dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
+      fi
+      ;;
 
-		debian|raspbian)
-			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
-			case "$dist_version" in
-				11)
-					dist_version="bullseye"
-				;;
-				10)
-					dist_version="buster"
-				;;
-				9)
-					dist_version="stretch"
-				;;
-				8)
-					dist_version="jessie"
-				;;
-			esac
-		;;
+    debian | raspbian)
+      dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
+      case "$dist_version" in
+        11)
+          dist_version="bullseye"
+          ;;
+        10)
+          dist_version="buster"
+          ;;
+        9)
+          dist_version="stretch"
+          ;;
+        8)
+          dist_version="jessie"
+          ;;
+      esac
+      ;;
 
-		centos|rhel|rocky|sles)
-			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
-				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-			fi
-		;;
+    centos | rhel | rocky | sles)
+      if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
+        dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
+      fi
+      ;;
 
-		*)
-			if command_exists lsb_release; then
-				dist_version="$(lsb_release --release | cut -f2)"
-			fi
-			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
-				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-			fi
-		;;
+    *)
+      if command_exists lsb_release; then
+        dist_version="$(lsb_release --release | cut -f2)"
+      fi
+      if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
+        dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
+      fi
+      ;;
 
-	esac
+  esac
 
-	# Check if this is a forked Linux distro
-	check_forked
+  # Check if this is a forked Linux distro
+  check_forked
 
-	# Print deprecation warnings for distro versions that recently reached EOL,
-	# but may still be commonly used (especially LTS versions).
-	case "$lsb_dist.$dist_version" in
-		debian.stretch|debian.jessie)
-			deprecation_notice "$lsb_dist" "$dist_version"
-			;;
-		raspbian.stretch|raspbian.jessie)
-			deprecation_notice "$lsb_dist" "$dist_version"
-			;;
-		ubuntu.xenial|ubuntu.trusty)
-			deprecation_notice "$lsb_dist" "$dist_version"
-			;;
-		fedora.*)
-			if [ "$dist_version" -lt 33 ]; then
-				deprecation_notice "$lsb_dist" "$dist_version"
-			fi
-			;;
-	esac
+  # Print deprecation warnings for distro versions that recently reached EOL,
+  # but may still be commonly used (especially LTS versions).
+  case "$lsb_dist.$dist_version" in
+    debian.stretch | debian.jessie)
+      deprecation_notice "$lsb_dist" "$dist_version"
+      ;;
+    raspbian.stretch | raspbian.jessie)
+      deprecation_notice "$lsb_dist" "$dist_version"
+      ;;
+    ubuntu.xenial | ubuntu.trusty)
+      deprecation_notice "$lsb_dist" "$dist_version"
+      ;;
+    fedora.*)
+      if [ "$dist_version" -lt 33 ]; then
+        deprecation_notice "$lsb_dist" "$dist_version"
+      fi
+      ;;
+  esac
 
-	# Run setup for each distro accordingly
-	case "$lsb_dist" in
-		ubuntu|debian|raspbian)
-			pre_reqs="apt-transport-https ca-certificates curl"
-			if ! command -v gpg > /dev/null; then
-				pre_reqs="$pre_reqs gnupg"
-			fi
-			apt_repo="deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
-			(
-				if ! is_dry_run; then
-					set -x
-				fi
-				$sh_c 'apt-get update -qq >/dev/null'
-				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
-				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | gpg --dearmor --yes -o /usr/share/keyrings/docker-archive-keyring.gpg"
-				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
-				$sh_c 'apt-get update -qq >/dev/null'
-			)
-			pkg_version=""
-			if [ -n "$VERSION" ]; then
-				if is_dry_run; then
-					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
-				else
-					# Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
-					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g").*-0~$lsb_dist"
-					search_command="apt-cache madison 'docker-ce' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
-					pkg_version="$($sh_c "$search_command")"
-					echo "INFO: Searching repository for VERSION '$VERSION'"
-					echo "INFO: $search_command"
-					if [ -z "$pkg_version" ]; then
-						echo
-						echo "ERROR: '$VERSION' not found amongst apt-cache madison results"
-						echo
-						exit 1
-					fi
-					if version_gte "18.09"; then
-							search_command="apt-cache madison 'docker-ce-cli' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
-							echo "INFO: $search_command"
-							cli_pkg_version="=$($sh_c "$search_command")"
-					fi
-					pkg_version="=$pkg_version"
-				fi
-			fi
-			(
-				pkgs=""
-				if version_gte "18.09"; then
-						# older versions don't support a cli package
-						pkgs="$pkgs docker-ce-cli${cli_pkg_version%=}"
-				fi
-				if version_gte "20.10" && [ "$(uname -m)" = "x86_64" ]; then
-						# also install the latest version of the "docker scan" cli-plugin (only supported on x86 currently)
-						pkgs="$pkgs docker-scan-plugin"
-				fi
-				pkgs="$pkgs docker-ce${pkg_version%=}"
-				if ! is_dry_run; then
-					set -x
-				fi
-				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends $pkgs >/dev/null"
-				if version_gte "20.10"; then
-					# Install docker-ce-rootless-extras without "--no-install-recommends", so as to install slirp4netns when available
-					$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-ce-rootless-extras${pkg_version%=} >/dev/null"
-				fi
-			)
-			echo_docker_as_nonroot
-			exit 0
-			;;
-		centos|fedora|rhel|rocky)
-			if [ "$lsb_dist" = "rocky" ]; then
-				yum_repo="$DOWNLOAD_URL/linux/centos/$REPO_FILE"
-			else
-				yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
-			fi
-			if ! curl -Ifs "$yum_repo" > /dev/null; then
-				echo "Error: Unable to curl repository file $yum_repo, is it valid?"
-				exit 1
-			fi
-			if [ "$lsb_dist" = "fedora" -o "$dist_version" = "8" ]; then
-				pkg_manager="dnf"
-				config_manager="dnf config-manager"
-				enable_channel_flag="--set-enabled"
-				disable_channel_flag="--set-disabled"
-				pre_reqs="dnf-plugins-core"
-				pkg_suffix="fc$dist_version"
-			else
-				pkg_manager="yum"
-				config_manager="yum-config-manager"
-				enable_channel_flag="--enable"
-				disable_channel_flag="--disable"
-				pre_reqs="yum-utils"
-				pkg_suffix="el"
-			fi
-			(
-				if ! is_dry_run; then
-					set -x
-				fi
-				$sh_c "$pkg_manager install -y -q $pre_reqs"
-				$sh_c "$config_manager --add-repo $yum_repo"
-				if [ "$dist_version" = "8" ]; then
-					sed -i '/^enabled=1/a module_hotfixes=1' /etc/yum.repos.d/$REPO_FILE
-				fi
-				if [ "$CHANNEL" != "stable" ]; then
-					$sh_c "$config_manager $disable_channel_flag docker-ce-*"
-					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
-				fi
-				$sh_c "$pkg_manager makecache"
-			)
-			pkg_version=""
-			if [ -n "$VERSION" ]; then
-				if is_dry_run; then
-					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
-				else
-					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g").*$pkg_suffix"
-					search_command="$pkg_manager list --showduplicates 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
-					pkg_version="$($sh_c "$search_command")"
-					echo "INFO: Searching repository for VERSION '$VERSION'"
-					echo "INFO: $search_command"
-					if [ -z "$pkg_version" ]; then
-						echo
-						echo "ERROR: '$VERSION' not found amongst $pkg_manager list results"
-						echo
-						exit 1
-					fi
-					if version_gte "18.09"; then
-						# older versions don't support a cli package
-						search_command="$pkg_manager list --showduplicates 'docker-ce-cli' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
-						cli_pkg_version="$($sh_c "$search_command" | cut -d':' -f 2)"
-					fi
-					# Cut out the epoch and prefix with a '-'
-					pkg_version="-$(echo "$pkg_version" | cut -d':' -f 2)"
-				fi
-			fi
-			(
-				if ! is_dry_run; then
-					set -x
-				fi
-				# install the correct cli version first
-				if [ -n "$cli_pkg_version" ]; then
-					$sh_c "$pkg_manager install -y -q docker-ce-cli-$cli_pkg_version"
-				fi
-				$sh_c "$pkg_manager install -y -q docker-ce$pkg_version"
-				if version_gte "20.10"; then
-					$sh_c "$pkg_manager install -y -q docker-ce-rootless-extras$pkg_version"
-				fi
-			)
-			echo_docker_as_nonroot
-			exit 0
-			;;
-		sles)
-			if [ "$(uname -m)" != "s390x" ]; then
-				echo "Packages for SLES are currently only available for s390x"
-				exit 1
-			fi
+  # Run setup for each distro accordingly
+  case "$lsb_dist" in
+    ubuntu | debian | raspbian)
+      pre_reqs="apt-transport-https ca-certificates curl"
+      if ! command -v gpg > /dev/null; then
+        pre_reqs="$pre_reqs gnupg"
+      fi
+      apt_repo="deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
+      (
+        if ! is_dry_run; then
+          set -x
+        fi
+        $sh_c 'apt-get update -qq >/dev/null'
+        $sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
+        $sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | gpg --dearmor --yes -o /usr/share/keyrings/docker-archive-keyring.gpg"
+        $sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
+        $sh_c 'apt-get update -qq >/dev/null'
+      )
+      pkg_version=""
+      if [ -n "$VERSION" ]; then
+        if is_dry_run; then
+          echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
+        else
+          # Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
+          pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g").*-0~$lsb_dist"
+          search_command="apt-cache madison 'docker-ce' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
+          pkg_version="$($sh_c "$search_command")"
+          echo "INFO: Searching repository for VERSION '$VERSION'"
+          echo "INFO: $search_command"
+          if [ -z "$pkg_version" ]; then
+            echo
+            echo "ERROR: '$VERSION' not found amongst apt-cache madison results"
+            echo
+            exit 1
+          fi
+          if version_gte "18.09"; then
+            search_command="apt-cache madison 'docker-ce-cli' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
+            echo "INFO: $search_command"
+            cli_pkg_version="=$($sh_c "$search_command")"
+          fi
+          pkg_version="=$pkg_version"
+        fi
+      fi
+      (
+        pkgs=""
+        if version_gte "18.09"; then
+          # older versions don't support a cli package
+          pkgs="$pkgs docker-ce-cli${cli_pkg_version%=}"
+        fi
+        if version_gte "20.10" && [ "$(uname -m)" = "x86_64" ]; then
+          # also install the latest version of the "docker scan" cli-plugin (only supported on x86 currently)
+          pkgs="$pkgs docker-scan-plugin"
+        fi
+        pkgs="$pkgs docker-ce${pkg_version%=}"
+        if ! is_dry_run; then
+          set -x
+        fi
+        $sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends $pkgs >/dev/null"
+        if version_gte "20.10"; then
+          # Install docker-ce-rootless-extras without "--no-install-recommends", so as to install slirp4netns when available
+          $sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-ce-rootless-extras${pkg_version%=} >/dev/null"
+        fi
+      )
+      echo_docker_as_nonroot
+      exit 0
+      ;;
+    centos | fedora | rhel | rocky)
+      if [ "$lsb_dist" = "rocky" ]; then
+        yum_repo="$DOWNLOAD_URL/linux/centos/$REPO_FILE"
+      else
+        yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
+      fi
+      if ! curl -Ifs "$yum_repo" > /dev/null; then
+        echo "Error: Unable to curl repository file $yum_repo, is it valid?"
+        exit 1
+      fi
+      if [ "$lsb_dist" = "fedora" -o "$dist_version" = "8" ]; then
+        pkg_manager="dnf"
+        config_manager="dnf config-manager"
+        enable_channel_flag="--set-enabled"
+        disable_channel_flag="--set-disabled"
+        pre_reqs="dnf-plugins-core"
+        pkg_suffix="fc$dist_version"
+      else
+        pkg_manager="yum"
+        config_manager="yum-config-manager"
+        enable_channel_flag="--enable"
+        disable_channel_flag="--disable"
+        pre_reqs="yum-utils"
+        pkg_suffix="el"
+      fi
+      (
+        if ! is_dry_run; then
+          set -x
+        fi
+        $sh_c "$pkg_manager install -y -q $pre_reqs"
+        $sh_c "$config_manager --add-repo $yum_repo"
+        if [ "$dist_version" = "8" ]; then
+          sed -i '/^enabled=1/a module_hotfixes=1' /etc/yum.repos.d/$REPO_FILE
+        fi
+        if [ "$CHANNEL" != "stable" ]; then
+          $sh_c "$config_manager $disable_channel_flag docker-ce-*"
+          $sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
+        fi
+        $sh_c "$pkg_manager makecache"
+      )
+      pkg_version=""
+      if [ -n "$VERSION" ]; then
+        if is_dry_run; then
+          echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
+        else
+          pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g").*$pkg_suffix"
+          search_command="$pkg_manager list --showduplicates 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
+          pkg_version="$($sh_c "$search_command")"
+          echo "INFO: Searching repository for VERSION '$VERSION'"
+          echo "INFO: $search_command"
+          if [ -z "$pkg_version" ]; then
+            echo
+            echo "ERROR: '$VERSION' not found amongst $pkg_manager list results"
+            echo
+            exit 1
+          fi
+          if version_gte "18.09"; then
+            # older versions don't support a cli package
+            search_command="$pkg_manager list --showduplicates 'docker-ce-cli' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
+            cli_pkg_version="$($sh_c "$search_command" | cut -d':' -f 2)"
+          fi
+          # Cut out the epoch and prefix with a '-'
+          pkg_version="-$(echo "$pkg_version" | cut -d':' -f 2)"
+        fi
+      fi
+      (
+        if ! is_dry_run; then
+          set -x
+        fi
+        # install the correct cli version first
+        if [ -n "$cli_pkg_version" ]; then
+          $sh_c "$pkg_manager install -y -q docker-ce-cli-$cli_pkg_version"
+        fi
+        $sh_c "$pkg_manager install -y -q docker-ce$pkg_version"
+        if version_gte "20.10"; then
+          $sh_c "$pkg_manager install -y -q docker-ce-rootless-extras$pkg_version"
+        fi
+      )
+      echo_docker_as_nonroot
+      exit 0
+      ;;
+    sles)
+      if [ "$(uname -m)" != "s390x" ]; then
+        echo "Packages for SLES are currently only available for s390x"
+        exit 1
+      fi
 
-			sles_version="${dist_version##*.}"
-			sles_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
-			opensuse_repo="https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP$sles_version/security:SELinux.repo"
-			if ! curl -Ifs "$sles_repo" > /dev/null; then
-				echo "Error: Unable to curl repository file $sles_repo, is it valid?"
-				exit 1
-			fi
-			pre_reqs="ca-certificates curl libseccomp2 awk"
-			(
-				if ! is_dry_run; then
-					set -x
-				fi
-				$sh_c "zypper install -y $pre_reqs"
-				$sh_c "zypper addrepo $sles_repo"
-				if ! is_dry_run; then
-						cat >&2 <<-'EOF'
-						WARNING!!
-						openSUSE repository (https://download.opensuse.org/repositories/security:SELinux) will be enabled now.
-						Do you wish to continue?
-						You may press Ctrl+C now to abort this script.
-						EOF
-						( set -x; sleep 30 )
-				fi
-				$sh_c "zypper addrepo $opensuse_repo"
-				$sh_c "zypper --gpg-auto-import-keys refresh"
-				$sh_c "zypper lr -d"
-			)
-			pkg_version=""
-			if [ -n "$VERSION" ]; then
-				if is_dry_run; then
-					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
-				else
-					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g")"
-					search_command="zypper search -s --match-exact 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$6}'"
-					pkg_version="$($sh_c "$search_command")"
-					echo "INFO: Searching repository for VERSION '$VERSION'"
-					echo "INFO: $search_command"
-					if [ -z "$pkg_version" ]; then
-						echo
-						echo "ERROR: '$VERSION' not found amongst zypper list results"
-						echo
-						exit 1
-					fi
-					search_command="zypper search -s --match-exact 'docker-ce-cli' | grep '$pkg_pattern' | tail -1 | awk '{print \$6}'"
-					# It's okay for cli_pkg_version to be blank, since older versions don't support a cli package
-					cli_pkg_version="$($sh_c "$search_command")"
-					pkg_version="-$pkg_version"
+      sles_version="${dist_version##*.}"
+      sles_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
+      opensuse_repo="https://download.opensuse.org/repositories/security:SELinux/SLE_15_SP$sles_version/security:SELinux.repo"
+      if ! curl -Ifs "$sles_repo" > /dev/null; then
+        echo "Error: Unable to curl repository file $sles_repo, is it valid?"
+        exit 1
+      fi
+      pre_reqs="ca-certificates curl libseccomp2 awk"
+      (
+        if ! is_dry_run; then
+          set -x
+        fi
+        $sh_c "zypper install -y $pre_reqs"
+        $sh_c "zypper addrepo $sles_repo"
+        if ! is_dry_run; then
+          cat >&2 <<- 'EOF'
+					WARNING!!
+					openSUSE repository (https://download.opensuse.org/repositories/security:SELinux) will be enabled now.
+					Do you wish to continue?
+					You may press Ctrl+C now to abort this script.
+				EOF
+          (
+            set -x
+            sleep 30
+          )
+        fi
+        $sh_c "zypper addrepo $opensuse_repo"
+        $sh_c "zypper --gpg-auto-import-keys refresh"
+        $sh_c "zypper lr -d"
+      )
+      pkg_version=""
+      if [ -n "$VERSION" ]; then
+        if is_dry_run; then
+          echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
+        else
+          pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g")"
+          search_command="zypper search -s --match-exact 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$6}'"
+          pkg_version="$($sh_c "$search_command")"
+          echo "INFO: Searching repository for VERSION '$VERSION'"
+          echo "INFO: $search_command"
+          if [ -z "$pkg_version" ]; then
+            echo
+            echo "ERROR: '$VERSION' not found amongst zypper list results"
+            echo
+            exit 1
+          fi
+          search_command="zypper search -s --match-exact 'docker-ce-cli' | grep '$pkg_pattern' | tail -1 | awk '{print \$6}'"
+          # It's okay for cli_pkg_version to be blank, since older versions don't support a cli package
+          cli_pkg_version="$($sh_c "$search_command")"
+          pkg_version="-$pkg_version"
 
-					search_command="zypper search -s --match-exact 'docker-ce-rootless-extras' | grep '$pkg_pattern' | tail -1 | awk '{print \$6}'"
-					rootless_pkg_version="$($sh_c "$search_command")"
-					rootless_pkg_version="-$rootless_pkg_version"
-				fi
-			fi
-			(
-				if ! is_dry_run; then
-					set -x
-				fi
-				# install the correct cli version first
-				if [ -n "$cli_pkg_version" ]; then
-					$sh_c "zypper install -y  docker-ce-cli-$cli_pkg_version"
-				fi
-				$sh_c "zypper install -y docker-ce$pkg_version"
-				if version_gte "20.10"; then
-					$sh_c "zypper install -y docker-ce-rootless-extras$rootless_pkg_version"
-				fi
-			)
-			echo_docker_as_nonroot
-			exit 0
-			;;
-		*)
-			if [ -z "$lsb_dist" ]; then
-				if is_darwin; then
-					echo
-					echo "ERROR: Unsupported operating system 'macOS'"
-					echo "Please get Docker Desktop from https://www.docker.com/products/docker-desktop"
-					echo
-					exit 1
-				fi
-			fi
-			echo
-			echo "ERROR: Unsupported distribution '$lsb_dist'"
-			echo
-			exit 1
-			;;
-	esac
-	exit 1
+          search_command="zypper search -s --match-exact 'docker-ce-rootless-extras' | grep '$pkg_pattern' | tail -1 | awk '{print \$6}'"
+          rootless_pkg_version="$($sh_c "$search_command")"
+          rootless_pkg_version="-$rootless_pkg_version"
+        fi
+      fi
+      (
+        if ! is_dry_run; then
+          set -x
+        fi
+        # install the correct cli version first
+        if [ -n "$cli_pkg_version" ]; then
+          $sh_c "zypper install -y  docker-ce-cli-$cli_pkg_version"
+        fi
+        $sh_c "zypper install -y docker-ce$pkg_version"
+        if version_gte "20.10"; then
+          $sh_c "zypper install -y docker-ce-rootless-extras$rootless_pkg_version"
+        fi
+      )
+      echo_docker_as_nonroot
+      exit 0
+      ;;
+    *)
+      if [ -z "$lsb_dist" ]; then
+        if is_darwin; then
+          echo
+          echo "ERROR: Unsupported operating system 'macOS'"
+          echo "Please get Docker Desktop from https://www.docker.com/products/docker-desktop"
+          echo
+          exit 1
+        fi
+      fi
+      echo
+      echo "ERROR: Unsupported distribution '$lsb_dist'"
+      echo
+      exit 1
+      ;;
+  esac
+  exit 1
 }
 
 # wrapped up in a function so that we have some protection against only getting

--- a/n_utils/includes/hook.sh
+++ b/n_utils/includes/hook.sh
@@ -45,7 +45,7 @@ execute_challenge_op() {
   local TOKEN_FILENAME="$3"
   local TOKEN_VALUE="$4"
   ZONE_ID=$(find_longest_hosted_zone_id $DOMAIN)
-cat > challenge.json << MARKER
+  cat > challenge.json << MARKER
 {
   "Changes": [{
     "Action": "$OPERATION",
@@ -101,7 +101,7 @@ deploy_cert() {
   store-secret.sh $DOMAIN.chained.crt < $CHAINED_CERT
   rm -f $CHAINED_CERT
   store-secret.sh logout
-#  rm -f $KEYFILE $CERTFILE $CHAINFILE
+  #  rm -f $KEYFILE $CERTFILE $CHAINFILE
 }
 
 unchanged_cert() {
@@ -118,10 +118,10 @@ unchanged_cert() {
   store-secret.sh $DOMAIN.chained.crt < $CHAINED_CERT
   rm -f $CHAINED_CERT
   store-secret.sh logout
-#  rm -f $KEYFILE $CERTFILE $CHAINFILE
+  #  rm -f $KEYFILE $CERTFILE $CHAINFILE
 }
 
 HANDLER=$1
 shift
-type $HANDLER &>/dev/null && echo "calling $HANDLER" || exit 0
+type $HANDLER &> /dev/null && echo "calling $HANDLER" || exit 0
 $HANDLER $@

--- a/n_utils/includes/install_tools.sh
+++ b/n_utils/includes/install_tools.sh
@@ -41,9 +41,9 @@ fi
 function add_gpg_key() {
   local key=$1
   gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ||
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ||
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||
-  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key"
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ||
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key"
 }
 
 function gpg_safe_download() {

--- a/n_utils/includes/install_tools.sh
+++ b/n_utils/includes/install_tools.sh
@@ -23,8 +23,14 @@ else
 fi
 rm -f /opt/nameless/instance-data.json
 
-OS_TYPE=$(source /etc/os-release; echo ${ID})
-OS_VERSION=$(source /etc/os-release; echo ${VERSION_ID})
+OS_TYPE=$(
+  source /etc/os-release
+  echo ${ID}
+)
+OS_VERSION=$(
+  source /etc/os-release
+  echo ${VERSION_ID}
+)
 if [ "$OS_TYPE" = "ubuntu" ]; then
   export LC_ALL="en_US.UTF-8"
   export LC_CTYPE="en_US.UTF-8"
@@ -34,9 +40,9 @@ fi
 
 function add_gpg_key() {
   local key=$1
-  gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ||
+  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ||
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||
   gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key"
 }
 
@@ -102,6 +108,6 @@ fi
 aws configure set default.s3.signature_version s3v4
 rm -f /opt/nameless/instance-data.json
 # Make sure we get logging
-if ! grep cloud-init-output.log /etc/cloud/cloud.cfg.d/05_logging.cfg > /dev/null ; then
+if ! grep cloud-init-output.log /etc/cloud/cloud.cfg.d/05_logging.cfg > /dev/null; then
   echo "output: {all: '| tee -a /var/log/cloud-init-output.log'}" >> /etc/cloud/cloud.cfg.d/05_logging.cfg
 fi

--- a/n_utils/includes/jenkins_tools.sh
+++ b/n_utils/includes/jenkins_tools.sh
@@ -16,7 +16,7 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common_tools.sh"
 
-jenkins_setup_dotssh () {
+jenkins_setup_dotssh() {
   check_parameters CF_paramDnsName
   DOT_SSH_DIR=/var/lib/jenkins/jenkins-home/.ssh
   mkdir -p $DOT_SSH_DIR
@@ -56,7 +56,7 @@ MARKER
   <master>$MASTER_PWD</master>
 </settingsSecurity>
 MARKER
-    chmod 600 "$MAVEN_HOME/settings-security.xml"
+      chmod 600 "$MAVEN_HOME/settings-security.xml"
     fi
     if ! [ -r "$MAVEN_HOME/settings.xml" ]; then
       cat > "$MAVEN_HOME/settings.xml" << MARKER
@@ -80,14 +80,14 @@ MARKER
   fi
 }
 
-jenkins_mount_ebs_home () {
+jenkins_mount_ebs_home() {
   check_parameters CF_paramEBSTag
   local SIZE=$1
   if [ -z "$SIZE" ]; then
     SIZE=32
   fi
   local MOUNT_PATH=/var/lib/jenkins/jenkins-home
-  ndt volume-from-snapshot --gp3 ${CF_paramEBSTag} ${CF_paramEBSTag} $MOUNT_PATH  $SIZE
+  ndt volume-from-snapshot --gp3 ${CF_paramEBSTag} ${CF_paramEBSTag} $MOUNT_PATH $SIZE
   usermod -d /var/lib/jenkins/jenkins-home jenkins
   mkdir -p /var/lib/jenkins/jenkins-home
   if ! [ -e /var/lib/jenkins/jenkins-home/config.xml ]; then
@@ -103,50 +103,48 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
 MARKER
 }
 
-
-jenkins_setup_snapshot_on_shutdown () {
+jenkins_setup_snapshot_on_shutdown() {
   local SYSCONFIG=/usr/lib/systemd/system/jenkins.service
-#  check_parameters CF_paramEBSTag
+  #  check_parameters CF_paramEBSTag
   sed -i -e "/ExecStart=.*/a ExecStopPost=/usr/local/bin/ndt snapshot-from-volume '${CF_paramEBSTag}' '${CF_paramEBSTag}' /var/lib/jenkins/jenkins-home" $SYSCONFIG
 }
 
-
-jenkins_discard_default_install () {
+jenkins_discard_default_install() {
   rm -rf /var/lib/jenkins-default
 }
 
-jenkins_fetch_additional_files () {
+jenkins_fetch_additional_files() {
   fetch-secrets.sh get 600 ${CF_paramAdditionalFiles}
-  for i in ${CF_paramAdditionalFiles} ; do
+  for i in ${CF_paramAdditionalFiles}; do
     case "$i" in
       /var/lib/jenkins/*)
-	      chown -R jenkins:jenkins "$i"
-	      ;;
+        chown -R jenkins:jenkins "$i"
+        ;;
     esac
   done
 }
 
-jenkins_improve_config_security () {
+jenkins_improve_config_security() {
   mkdir -p /var/lib/jenkins/jenkins-home/secrets/
   echo false > /var/lib/jenkins/jenkins-home/secrets/slave-to-master-security-kill-switch
 }
 
-jenkins_set_home () {
+jenkins_set_home() {
   local SYSCONFIG=/usr/lib/systemd/system/jenkins.service
   [ -n "$CF_paramJenkinsStartTimeOut" ] || CF_paramJenkinsStartTimeOut=300
   sed -i -e 's/Environment=\"JENKINS_HOME=.*/Environment=\"JENKINS_HOME=\/var\/lib\/jenkins\/jenkins-home\"/g' \
-  -e 's/WorkingDirectory=.*/WorkingDirectory=\/var\/lib\/jenkins\/jenkins-home/g' \
-  -e 's/Environment=\"JAVA_OPTS=.*/Environment=\"JAVA_OPTS=-Djava.awt.headless=true -Dhudson.model.DirectoryBrowserSupport.CSP= -Dhudson.model.User.SECURITY_243_FULL_DEFENSE=false -Dhudson.model.ParametersAction.keepUndefinedParameters=true\"/g' \
-  -e '/Environment=\"JENKINS_PORT=.*/a Environment=\"JENKINS_AJP_PORT=-1\"' \
-  -e 's/^.*TimeoutStartSec=.*$/TimeoutStartSec='$CF_paramJenkinsStartTimeOut'/g' $SYSCONFIG
+    -e 's/WorkingDirectory=.*/WorkingDirectory=\/var\/lib\/jenkins\/jenkins-home/g' \
+    -e 's/Environment=\"JAVA_OPTS=.*/Environment=\"JAVA_OPTS=-Djava.awt.headless=true -Dhudson.model.DirectoryBrowserSupport.CSP= -Dhudson.model.User.SECURITY_243_FULL_DEFENSE=false -Dhudson.model.ParametersAction.keepUndefinedParameters=true\"/g' \
+    -e '/Environment=\"JENKINS_PORT=.*/a Environment=\"JENKINS_AJP_PORT=-1\"' \
+    -e 's/^.*TimeoutStartSec=.*$/TimeoutStartSec='$CF_paramJenkinsStartTimeOut'/g' $SYSCONFIG
 }
 
-jenkins_disable_and_shutdown_service () {
+jenkins_disable_and_shutdown_service() {
   systemctl disable jenkins
   systemctl stop jenkins
 }
 
-jenkins_enable_and_start_service () {
+jenkins_enable_and_start_service() {
   chown -R jenkins:jenkins /var/lib/jenkins/ /var/lib/jenkins/jenkins-home/
   systemctl enable jenkins
   systemctl start jenkins
@@ -164,7 +162,7 @@ jenkins_setup() {
   jenkins_enable_and_start_service
 }
 
-jenkins_wait_service_up () {
+jenkins_wait_service_up() {
   # Tests to see if everything is OK
   COUNT=0
   SERVER=""

--- a/n_utils/includes/lastpass-login.sh
+++ b/n_utils/includes/lastpass-login.sh
@@ -38,13 +38,13 @@ if [ ! "$LPASS_USER" -o ! "$LPASS_PASSFILE" ]; then
 fi
 
 if [ "$LPASS_PASSFILE" = "-" ]; then
-  LPASS_DISABLE_PINENTRY=1 lpass login --plaintext-key -f "$LPASS_USER" 2>&1 >/dev/null
+  LPASS_DISABLE_PINENTRY=1 lpass login --plaintext-key -f "$LPASS_USER" 2>&1 > /dev/null
 else
   if ! [ -r "$LPASS_PASSFILE" -a "$(stat -c '%a' "$LPASS_PASSFILE")" = "600" ]; then
     echo "Requires $LPASS_PASSFILE with only user access with the lastpass password"
     exit 1
   fi
-  LPASS_DISABLE_PINENTRY=1 lpass login --plaintext-key -f "$LPASS_USER" < "$LPASS_PASSFILE" 2>&1 >/dev/null
+  LPASS_DISABLE_PINENTRY=1 lpass login --plaintext-key -f "$LPASS_USER" < "$LPASS_PASSFILE" 2>&1 > /dev/null
 fi
 
-lpass sync 2>&1 >/dev/null
+lpass sync 2>&1 > /dev/null

--- a/n_utils/includes/lastpass-logout.sh
+++ b/n_utils/includes/lastpass-logout.sh
@@ -17,4 +17,4 @@
 if [ "$_ARGCOMPLETE" ]; then
   exit 0
 fi
-LPASS_DISABLE_PINENTRY=1 lpass logout -f 2>&1 >/dev/null
+LPASS_DISABLE_PINENTRY=1 lpass logout -f 2>&1 > /dev/null

--- a/n_utils/includes/letsencrypt.sh
+++ b/n_utils/includes/letsencrypt.sh
@@ -552,23 +552,23 @@ init_system() {
   if [[ ${API} -eq 1 ]]; then
     # shellcheck disable=SC2015
     CA_NEW_CERT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value new-cert)" &&
-    CA_NEW_AUTHZ="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value new-authz)" &&
-    CA_NEW_REG="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value new-reg)" &&
-    CA_TERMS="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value terms-of-service)" &&
-    CA_REQUIRES_EAB="false" &&
-    CA_REVOKE_CERT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value revoke-cert)" ||
-    _exiterr "Problem retrieving ACME/CA-URLs, check if your configured CA points to the directory entrypoint."
+      CA_NEW_AUTHZ="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value new-authz)" &&
+      CA_NEW_REG="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value new-reg)" &&
+      CA_TERMS="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value terms-of-service)" &&
+      CA_REQUIRES_EAB="false" &&
+      CA_REVOKE_CERT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value revoke-cert)" ||
+      _exiterr "Problem retrieving ACME/CA-URLs, check if your configured CA points to the directory entrypoint."
     # Since reg URI is missing from directory we will assume it is the same as CA_NEW_REG without the new part
     CA_REG=${CA_NEW_REG/new-reg/reg}
   else
     # shellcheck disable=SC2015
     CA_NEW_ORDER="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newOrder)" &&
-    CA_NEW_NONCE="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newNonce)" &&
-    CA_NEW_ACCOUNT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newAccount)" &&
-    CA_TERMS="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value -p '"meta","termsOfService"')" &&
-    CA_REQUIRES_EAB="$(printf "%s" "${CA_DIRECTORY}" | get_json_bool_value -p '"meta","externalAccountRequired"' || echo false)" &&
-    CA_REVOKE_CERT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value revokeCert)" ||
-    _exiterr "Problem retrieving ACME/CA-URLs, check if your configured CA points to the directory entrypoint."
+      CA_NEW_NONCE="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newNonce)" &&
+      CA_NEW_ACCOUNT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newAccount)" &&
+      CA_TERMS="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value -p '"meta","termsOfService"')" &&
+      CA_REQUIRES_EAB="$(printf "%s" "${CA_DIRECTORY}" | get_json_bool_value -p '"meta","externalAccountRequired"' || echo false)" &&
+      CA_REVOKE_CERT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value revokeCert)" ||
+      _exiterr "Problem retrieving ACME/CA-URLs, check if your configured CA points to the directory entrypoint."
     # Since acct URI is missing from directory we will assume it is the same as CA_NEW_ACCOUNT without the new part
     CA_ACCOUNT=${CA_NEW_ACCOUNT/new-acct/acct}
   fi

--- a/n_utils/includes/letsencrypt.sh
+++ b/n_utils/includes/letsencrypt.sh
@@ -22,22 +22,22 @@ VERSION="0.7.1"
 # Find directory in which this script is stored by traversing all symbolic links
 SOURCE="${0}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
   SOURCE="$(readlink "$SOURCE")"
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
-SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+SCRIPTDIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
 BASEDIR="${SCRIPTDIR}"
 ORIGARGS=("${@}")
 
 # Generate json.sh path matching string
 json_path() {
-	if [ ! "${1}" = "-p" ]; then
-		printf '"%s"' "${1}"
-	else
-		printf '%s' "${2}"
-	fi
+  if [ ! "${1}" = "-p" ]; then
+    printf '"%s"' "${1}"
+  else
+    printf '%s' "${2}"
+  fi
 }
 
 # Get string value from json dictionary
@@ -55,7 +55,7 @@ get_json_array_values() {
 # Get sub-dictionary from json
 get_json_dict_value() {
   local filter
-	echo "$(json_path "${1:-}" "${2:-}")"
+  echo "$(json_path "${1:-}" "${2:-}")"
   filter="$(printf 's/.*\[%s\][[:space:]]*\(.*\)/\\1/p' "$(json_path "${1:-}" "${2:-}")")"
   sed -n "${filter}" | jsonsh
 }
@@ -85,7 +85,7 @@ jsonsh() {
     exit 1
   }
 
-  awk_egrep () {
+  awk_egrep() {
     local pattern_string=$1
 
     gawk '{
@@ -98,20 +98,18 @@ jsonsh() {
     }' pattern="$pattern_string"
   }
 
-  tokenize () {
+  tokenize() {
     local GREP
     local ESCAPE
     local CHAR
 
-    if echo "test string" | egrep -ao --color=never "test" >/dev/null 2>&1
-    then
+    if echo "test string" | egrep -ao --color=never "test" > /dev/null 2>&1; then
       GREP='egrep -ao --color=never'
     else
       GREP='egrep -ao'
     fi
 
-    if echo "test string" | egrep -o "test" >/dev/null 2>&1
-    then
+    if echo "test string" | egrep -o "test" > /dev/null 2>&1; then
       ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
       CHAR='[^[:cntrl:]"\\]'
     else
@@ -126,23 +124,22 @@ jsonsh() {
     local SPACE='[[:space:]]+'
 
     # Force zsh to expand $A into multiple words
-    local is_wordsplit_disabled=$(unsetopt 2>/dev/null | grep -c '^shwordsplit$')
+    local is_wordsplit_disabled=$(unsetopt 2> /dev/null | grep -c '^shwordsplit$')
     if [ $is_wordsplit_disabled != 0 ]; then setopt shwordsplit; fi
     $GREP "$STRING|$NUMBER|$KEYWORD|$SPACE|." | egrep -v "^$SPACE$"
     if [ $is_wordsplit_disabled != 0 ]; then unsetopt shwordsplit; fi
   }
 
-  parse_array () {
+  parse_array() {
     local index=0
     local ary=''
     read -r token
     case "$token" in
       ']') ;;
       *)
-        while :
-        do
+        while :; do
           parse_value "$1" "$index"
-          index=$((index+1))
+          index=$((index + 1))
           ary="$ary""$value"
           read -r token
           case "$token" in
@@ -158,15 +155,14 @@ jsonsh() {
     :
   }
 
-  parse_object () {
+  parse_object() {
     local key
     local obj=''
     read -r token
     case "$token" in
       '}') ;;
       *)
-        while :
-        do
+        while :; do
           case "$token" in
             '"'*'"') key=$token ;;
             *) throw "EXPECTED string GOT ${token:-EOF}" ;;
@@ -187,25 +183,26 @@ jsonsh() {
           esac
           read -r token
         done
-      ;;
+        ;;
     esac
     value=$(printf '{%s}' "$obj") || value=
     :
   }
 
-  parse_value () {
+  parse_value() {
     local jpath="${1:+$1,}${2:-}" isleaf=0 isempty=0 print=0
     case "$token" in
       '{') parse_object "$jpath" ;;
-      '[') parse_array  "$jpath" ;;
+      '[') parse_array "$jpath" ;;
       # At this point, the only valid single-character tokens are digits.
-      ''|[!0-9]) throw "EXPECTED value GOT ${token:-EOF}" ;;
-      *) value=$token
-         # replace solidus ("\/") in json strings with normalized value: "/"
-         value=$(echo "$value" | sed 's#\\/#/#g')
-         isleaf=1
-         [ "$value" = '""' ] && isempty=1
-         ;;
+      '' | [!0-9]) throw "EXPECTED value GOT ${token:-EOF}" ;;
+      *)
+        value=$token
+        # replace solidus ("\/") in json strings with normalized value: "/"
+        value=$(echo "$value" | sed 's#\\/#/#g')
+        isleaf=1
+        [ "$value" = '""' ] && isempty=1
+        ;;
     esac
     [ "$value" = '' ] && return
     [ -z "$jpath" ] && return # do not print head
@@ -214,7 +211,7 @@ jsonsh() {
     :
   }
 
-  parse () {
+  parse() {
     read -r token
     parse_value
     read -r token || true
@@ -237,7 +234,7 @@ _mktemp() {
 check_dependencies() {
   # look for required binaries
   for binary in grep mktemp diff sed awk curl cut; do
-    bin_path="$(command -v "${binary}" 2>/dev/null)" || _exiterr "This script requires ${binary}."
+    bin_path="$(command -v "${binary}" 2> /dev/null)" || _exiterr "This script requires ${binary}."
     [[ -x "${bin_path}" ]] || _exiterr "${binary} found in PATH but it's not executable"
   done
 
@@ -536,7 +533,10 @@ init_system() {
   if [[ -n "${LOCKFILE}" ]]; then
     LOCKDIR="$(dirname "${LOCKFILE}")"
     [[ -w "${LOCKDIR}" ]] || _exiterr "Directory ${LOCKDIR} for LOCKFILE ${LOCKFILE} is not writable, aborting."
-    ( set -C; date > "${LOCKFILE}" ) 2>/dev/null || _exiterr "Lock file '${LOCKFILE}' present, aborting."
+    (
+      set -C
+      date > "${LOCKFILE}"
+    ) 2> /dev/null || _exiterr "Lock file '${LOCKFILE}' present, aborting."
     remove_lock() { rm -f "${LOCKFILE}"; }
     trap 'remove_lock' EXIT
   fi
@@ -605,7 +605,7 @@ init_system() {
       register_new_key="yes"
     fi
   fi
-  "${OPENSSL}" rsa -in "${ACCOUNT_KEY}" -check 2>/dev/null > /dev/null || _exiterr "Account key is not valid, cannot continue."
+  "${OPENSSL}" rsa -in "${ACCOUNT_KEY}" -check 2> /dev/null > /dev/null || _exiterr "Account key is not valid, cannot continue."
 
   # Get public components from private key and calculate thumbprint
   pubExponent64="$(printf '%x' "$("${OPENSSL}" rsa -in "${ACCOUNT_KEY}" -noout -text | awk '/publicExponent/ {print $2}')" | hex2bin | urlbase64)"
@@ -625,7 +625,7 @@ init_system() {
 
     # ZeroSSL special sauce
     if [[ "${CA}" = "${CA_ZEROSSL}" ]]; then
-      if [[ -z "${EAB_KID:-}" ]] ||  [[ -z "${EAB_HMAC_KEY:-}" ]]; then
+      if [[ -z "${EAB_KID:-}" ]] || [[ -z "${EAB_HMAC_KEY:-}" ]]; then
         if [[ -z "${CONTACT_EMAIL}" ]]; then
           echo "ZeroSSL requires contact email to be set or EAB_KID/EAB_HMAC_KEY to be manually configured"
           FAILED=true
@@ -633,7 +633,7 @@ init_system() {
           zeroapi="$(curl -s "https://api.zerossl.com/acme/eab-credentials-email" -d "email=${CONTACT_EMAIL}" | jsonsh)"
           EAB_KID="$(printf "%s" "${zeroapi}" | get_json_string_value eab_kid)"
           EAB_HMAC_KEY="$(printf "%s" "${zeroapi}" | get_json_string_value eab_hmac_key)"
-          if [[ -z "${EAB_KID:-}" ]] ||  [[ -z "${EAB_HMAC_KEY:-}" ]]; then
+          if [[ -z "${EAB_KID:-}" ]] || [[ -z "${EAB_HMAC_KEY:-}" ]]; then
             echo "Unknown error retrieving ZeroSSL API credentials"
             echo "${zeroapi}"
             FAILED=true
@@ -764,7 +764,8 @@ deurlbase64() {
   data="$(cat | tr -d ' \n\r')"
   modlen=$((${#data} % 4))
   padding=""
-  if [[ "${modlen}" = "2" ]]; then padding="==";
+  if [[ "${modlen}" = "2" ]]; then
+    padding="=="
   elif [[ "${modlen}" = "3" ]]; then padding="="; fi
   printf "%s%s" "${data}" "${padding}" | tr -d '\n\r' | _sed -e 'y:-_:+/:' | "${OPENSSL}" base64 -d -A
 }
@@ -803,7 +804,7 @@ http_request() {
   tempheaders="$(_mktemp)"
 
   if [[ -n "${IP_VERSION:-}" ]]; then
-      ip_version="-${IP_VERSION}"
+    ip_version="-${IP_VERSION}"
   fi
 
   set +e
@@ -860,7 +861,7 @@ http_request() {
     fi
   fi
 
-  if { true >&4; } 2>/dev/null; then
+  if { true >&4; } 2> /dev/null; then
     cat "${tempheaders}" >&4
   fi
   cat "${tempcont}"
@@ -916,41 +917,41 @@ signed_request() {
 extract_altnames() {
   csr="${1}" # the CSR itself (not a file)
 
-  if ! <<<"${csr}" "${OPENSSL}" req -verify -noout 2>/dev/null; then
+  if ! "${OPENSSL}" <<< "${csr}" req -verify -noout 2> /dev/null; then
     _exiterr "Certificate signing request isn't valid"
   fi
 
-  reqtext="$( <<<"${csr}" "${OPENSSL}" req -noout -text )"
-  if <<<"${reqtext}" grep -q '^[[:space:]]*X509v3 Subject Alternative Name:[[:space:]]*$'; then
+  reqtext="$("${OPENSSL}" <<< "${csr}" req -noout -text)"
+  if grep <<< "${reqtext}" -q '^[[:space:]]*X509v3 Subject Alternative Name:[[:space:]]*$'; then
     # SANs used, extract these
-    altnames="$( <<<"${reqtext}" awk '/X509v3 Subject Alternative Name:/{print;getline;print;}' | tail -n1 )"
+    altnames="$(awk <<< "${reqtext}" '/X509v3 Subject Alternative Name:/{print;getline;print;}' | tail -n1)"
     # split to one per line:
     # shellcheck disable=SC1003
-    altnames="$( <<<"${altnames}" _sed -e 's/^[[:space:]]*//; s/, /\'$'\n''/g' )"
+    altnames="$(_sed <<< "${altnames}" -e 's/^[[:space:]]*//; s/, /\'$'\n''/g')"
     # we can only get DNS: ones signed
-    if grep -qEv '^(DNS|othername):' <<<"${altnames}"; then
+    if grep -qEv '^(DNS|othername):' <<< "${altnames}"; then
       _exiterr "Certificate signing request contains non-DNS Subject Alternative Names"
     fi
     # strip away the DNS: prefix
-    altnames="$( <<<"${altnames}" _sed -e 's/^(DNS:|othername:<unsupported>)//' )"
+    altnames="$(_sed <<< "${altnames}" -e 's/^(DNS:|othername:<unsupported>)//')"
     printf "%s" "${altnames}" | tr '\n' ' '
   else
     # No SANs, extract CN
-    altnames="$( <<<"${reqtext}" grep '^[[:space:]]*Subject:' | _sed -e 's/.*[ /]CN ?= ?([^ /,]*).*/\1/' )"
+    altnames="$(grep <<< "${reqtext}" '^[[:space:]]*Subject:' | _sed -e 's/.*[ /]CN ?= ?([^ /,]*).*/\1/')"
     printf "%s" "${altnames}"
   fi
 }
 
 # Get last issuer CN in certificate chain
 get_last_cn() {
-  <<<"${1}" _sed 'H;/-----BEGIN CERTIFICATE-----/h;$!d;x' | "${OPENSSL}" x509 -noout -issuer | head -n1 | _sed -e 's/.*[ /]CN ?= ?([^/,]*).*/\1/'
+  _sed <<< "${1}" 'H;/-----BEGIN CERTIFICATE-----/h;$!d;x' | "${OPENSSL}" x509 -noout -issuer | head -n1 | _sed -e 's/.*[ /]CN ?= ?([^/,]*).*/\1/'
 }
 
 # Create certificate for domain(s) and outputs it FD 3
 sign_csr() {
   csr="${1}" # the CSR itself (not a file)
 
-  if { true >&3; } 2>/dev/null; then
+  if { true >&3; } 2> /dev/null; then
     : # fd 3 looks OK
   else
     _exiterr "sign_csr: FD 3 not open"
@@ -992,7 +993,7 @@ sign_csr() {
     local idx=0
     for uri in ${order_authorizations}; do
       authorizations[${idx}]="${uri}"
-      idx=$((idx+1))
+      idx=$((idx + 1))
     done
     echo " + Received ${idx} authorizations URLs from the CA"
   else
@@ -1000,7 +1001,7 @@ sign_csr() {
     local idx=0
     for altname in ${altnames}; do
       authorizations[${idx}]="${altname}"
-      idx=$((idx+1))
+      idx=$((idx + 1))
     done
   fi
 
@@ -1074,7 +1075,7 @@ sign_csr() {
     keyauths[${idx}]="${keyauth}"
     deploy_args[${idx}]="${identifier} ${challenge_tokens[${idx}]} ${keyauth_hook}"
 
-    idx=$((idx+1))
+    idx=$((idx + 1))
   done
   local num_pending_challenges=${idx}
   echo " + ${num_pending_challenges} pending challenge(s)"
@@ -1089,7 +1090,7 @@ sign_csr() {
       local idx=0
       while [ ${idx} -lt ${num_pending_challenges} ]; do
         "${HOOK}" "deploy_challenge" ${deploy_args[${idx}]} || _exiterr 'deploy_challenge hook returned with non-zero exit code'
-        idx=$((idx+1))
+        idx=$((idx + 1))
       done
     fi
   fi
@@ -1127,7 +1128,7 @@ sign_csr() {
       [[ -n "${HOOK}" ]] && ("${HOOK}" "invalid_challenge" "${altname}" "${result}" || _exiterr 'invalid_challenge hook returned with non-zero exit code')
       break
     fi
-    idx=$((idx+1))
+    idx=$((idx + 1))
   done
 
   if [[ ${num_pending_challenges} -ne 0 ]]; then
@@ -1145,7 +1146,7 @@ sign_csr() {
       [[ "${CHALLENGETYPE}" = "tls-alpn-01" ]] && rm -f "${ALPNCERTDIR}/${challenge_names[${idx}]}.crt.pem" "${ALPNCERTDIR}/${challenge_names[${idx}]}.key.pem"
       # Clean challenge token using non-chained hook
       [[ -n "${HOOK}" ]] && [[ "${HOOK_CHAIN}" != "yes" ]] && ("${HOOK}" "clean_challenge" ${deploy_args[${idx}]} || _exiterr 'clean_challenge hook returned with non-zero exit code')
-      idx=$((idx+1))
+      idx=$((idx + 1))
     done
 
     if [[ "${reqstatus}" != "valid" ]]; then
@@ -1156,22 +1157,21 @@ sign_csr() {
 
   # Finally request certificate from the acme-server and store it in cert-${timestamp}.pem and link from cert.pem
   echo " + Requesting certificate..."
-  csr64="$( <<<"${csr}" "${OPENSSL}" req -config "${OPENSSL_CNF}" -outform DER | urlbase64)"
+  csr64="$("${OPENSSL}" <<< "${csr}" req -config "${OPENSSL_CNF}" -outform DER | urlbase64)"
   if [[ ${API} -eq 1 ]]; then
     crt64="$(signed_request "${CA_NEW_CERT}" '{"resource": "new-cert", "csr": "'"${csr64}"'"}' | "${OPENSSL}" base64 -e)"
-    crt="$( printf -- '-----BEGIN CERTIFICATE-----\n%s\n-----END CERTIFICATE-----\n' "${crt64}" )"
+    crt="$(printf -- '-----BEGIN CERTIFICATE-----\n%s\n-----END CERTIFICATE-----\n' "${crt64}")"
   else
     result="$(signed_request "${finalize}" '{"csr": "'"${csr64}"'"}' | jsonsh)"
     while :; do
       orderstatus="$(echo "${result}" | get_json_string_value status)"
-      case "${orderstatus}"
-      in
+      case "${orderstatus}" in
         "processing" | "pending")
           echo " + Order is ${orderstatus}..."
-          sleep 2;
+          sleep 2
           ;;
         "valid")
-          break;
+          break
           ;;
         *)
           _exiterr "Order in status ${orderstatus}"
@@ -1182,7 +1182,7 @@ sign_csr() {
 
     resheaders="$(_mktemp)"
     certificate="$(echo "${result}" | get_json_string_value certificate)"
-    crt="$(signed_request "${certificate}" "" 4>"${resheaders}")"
+    crt="$(signed_request "${certificate}" "" 4> "${resheaders}")"
 
     if [ -n "${PREFERRED_CHAIN:-}" ]; then
       foundaltchain=0
@@ -1214,7 +1214,7 @@ sign_csr() {
 
   # Try to load the certificate to detect corruption
   echo " + Checking certificate..."
-  _openssl x509 -text <<<"${crt}"
+  _openssl x509 -text <<< "${crt}"
 
   echo "${crt}" >&3
 
@@ -1257,13 +1257,17 @@ walk_chain() {
     http_request get "${issuer_cert_uri}" > "${tmpcert_raw}"
 
     # PEM
-    if grep -q "BEGIN CERTIFICATE" "${tmpcert_raw}"; then mv "${tmpcert_raw}" "${tmpcert}"
+    if grep -q "BEGIN CERTIFICATE" "${tmpcert_raw}"; then
+      mv "${tmpcert_raw}" "${tmpcert}"
     # DER
-    elif "${OPENSSL}" x509 -in "${tmpcert_raw}" -inform DER -out "${tmpcert}" -outform PEM 2> /dev/null > /dev/null; then :
+    elif "${OPENSSL}" x509 -in "${tmpcert_raw}" -inform DER -out "${tmpcert}" -outform PEM 2> /dev/null > /dev/null; then
+      :
     # PKCS7
-    elif "${OPENSSL}" pkcs7 -in "${tmpcert_raw}" -inform DER -out "${tmpcert}" -outform PEM -print_certs 2> /dev/null > /dev/null; then :
+    elif "${OPENSSL}" pkcs7 -in "${tmpcert_raw}" -inform DER -out "${tmpcert}" -outform PEM -print_certs 2> /dev/null > /dev/null; then
+      :
     # Unknown certificate type
-    else _exiterr "Unknown certificate type in chain"
+    else
+      _exiterr "Unknown certificate type in chain"
     fi
 
     local next_issuer_cert_uri
@@ -1328,8 +1332,8 @@ sign_domain() {
       privkey="privkey-${timestamp}.pem"
       local tmp_privkey="$(_mktemp)"
       case "${KEY_ALGO}" in
-        rsa) _openssl genrsa -out "${tmp_privkey}" "${KEYSIZE}";;
-        prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${tmp_privkey}";;
+        rsa) _openssl genrsa -out "${tmp_privkey}" "${KEYSIZE}" ;;
+        prime256v1 | secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${tmp_privkey}" ;;
       esac
       cat "${tmp_privkey}" > "${certdir}/privkey-${timestamp}.pem"
       rm "${tmp_privkey}"
@@ -1345,8 +1349,8 @@ sign_domain() {
     if [[ ! -r "${certdir}/privkey.roll.pem" && "${PRIVATE_KEY_ROLLOVER}" = "yes" && "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
       echo " + Generating private rollover key..."
       case "${KEY_ALGO}" in
-        rsa) _openssl genrsa -out "${certdir}/privkey.roll.pem" "${KEYSIZE}";;
-        prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${certdir}/privkey.roll.pem";;
+        rsa) _openssl genrsa -out "${certdir}/privkey.roll.pem" "${KEYSIZE}" ;;
+        prime256v1 | secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${certdir}/privkey.roll.pem" ;;
       esac
     fi
     # delete rolloverkeys if disabled
@@ -1381,7 +1385,7 @@ sign_domain() {
 
   crt_path="${certdir}/cert-${timestamp}.pem"
   # shellcheck disable=SC2086
-  sign_csr "$(< "${certdir}/cert-${timestamp}.csr")" ${altnames} 3>"${crt_path}"
+  sign_csr "$(< "${certdir}/cert-${timestamp}.csr")" ${altnames} 3> "${crt_path}"
 
   # Create fullchain.pem
   echo " + Creating fullchain.pem..."
@@ -1437,15 +1441,18 @@ command_version() {
   echo "https://dehydrated.io"
   echo ""
   echo "Dehydrated version: ${VERSION}"
-  revision="$(cd "${SCRIPTDIR}"; git rev-parse HEAD 2>/dev/null || echo "unknown")"
+  revision="$(
+    cd "${SCRIPTDIR}"
+    git rev-parse HEAD 2> /dev/null || echo "unknown"
+  )"
   echo "GIT-Revision: ${revision}"
   echo ""
   if [[ "${OSTYPE}" =~ "BSD" ]]; then
     echo "OS: $(uname -sr)"
   elif [[ -e /etc/os-release ]]; then
-    ( . /etc/os-release && echo "OS: $PRETTY_NAME" )
+    (. /etc/os-release && echo "OS: $PRETTY_NAME")
   elif [[ -e /usr/lib/os-release ]]; then
-    ( . /usr/lib/os-release && echo "OS: $PRETTY_NAME" )
+    (. /usr/lib/os-release && echo "OS: $PRETTY_NAME")
   else
     echo "OS: $(cat /etc/issue | grep -v ^$ | head -n1 | _sed 's/\\(r|n|l) .*//g')"
   fi
@@ -1564,12 +1571,12 @@ command_sign_domains() {
   # Generate certificates for all domains found in domains.txt. Check if existing certificate are about to expire
   ORIGIFS="${IFS}"
   IFS=$'\n'
-  for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
+  for line in $(tr < "${DOMAINS_TXT}" -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
     reset_configvars
     IFS="${ORIGIFS}"
     alias="$(grep -Eo '>[^ ]+' <<< "${line}" || true)"
     line="$(_sed -e 's/>[^ ]+[ ]*//g' <<< "${line}")"
-    aliascount="$(grep -Eo '>' <<< "${alias}" | awk 'END {print NR}' || true )"
+    aliascount="$(grep -Eo '>' <<< "${alias}" | awk 'END {print NR}' || true)"
     [ ${aliascount} -gt 1 ] && _exiterr "Only one alias per line is allowed in domains.txt!"
 
     domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
@@ -1577,7 +1584,7 @@ command_sign_domains() {
     [ ${aliascount} -lt 1 ] && alias="${domain}" || alias="${alias#>}"
     export alias
 
-    if [[ -z "${morenames}" ]];then
+    if [[ -z "${morenames}" ]]; then
       echo "Processing ${domain}"
     else
       echo "Processing ${domain} with alternative names: ${morenames}"
@@ -1628,15 +1635,15 @@ command_sign_domains() {
       ); do
         config_var="$(echo "${cfgline:1}" | cut -d'=' -f1)"
         config_value="$(echo "${cfgline:1}" | cut -d'=' -f2- | tr -d "'")"
-	# All settings that are allowed here should also be stored and
-	# restored in store_configvars() and reset_configvars()
+        # All settings that are allowed here should also be stored and
+        # restored in store_configvars() and reset_configvars()
         case "${config_var}" in
-          KEY_ALGO|OCSP_MUST_STAPLE|OCSP_FETCH|OCSP_DAYS|PRIVATE_KEY_RENEW|PRIVATE_KEY_ROLLOVER|KEYSIZE|CHALLENGETYPE|HOOK|PREFERRED_CHAIN|WELLKNOWN|HOOK_CHAIN|OPENSSL_CNF|RENEW_DAYS)
+          KEY_ALGO | OCSP_MUST_STAPLE | OCSP_FETCH | OCSP_DAYS | PRIVATE_KEY_RENEW | PRIVATE_KEY_ROLLOVER | KEYSIZE | CHALLENGETYPE | HOOK | PREFERRED_CHAIN | WELLKNOWN | HOOK_CHAIN | OPENSSL_CNF | RENEW_DAYS)
             echo "   + ${config_var} = ${config_value}"
             declare -- "${config_var}=${config_value}"
             ;;
           _) ;;
-          *) echo "   ! Setting ${config_var} on a per-certificate base is not (yet) supported" >&2
+          *) echo "   ! Setting ${config_var} on a per-certificate base is not (yet) supported" >&2 ;;
         esac
       done
       IFS="${ORIGIFS}"
@@ -1666,7 +1673,7 @@ command_sign_domains() {
       printf " + Checking domain name(s) of existing cert..."
 
       certnames="$("${OPENSSL}" x509 -in "${cert}" -text -noout | grep DNS: | _sed 's/DNS://g' | tr -d ' ' | tr ',' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//')"
-      givennames="$(echo "${domain}" "${morenames}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
+      givennames="$(echo "${domain}" "${morenames}" | tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
 
       if [[ "${certnames}" = "${givennames}" ]]; then
         echo " unchanged."
@@ -1683,7 +1690,7 @@ command_sign_domains() {
     # Check expire date of existing certificate
     if [[ -e "${cert}" ]]; then
       echo " + Checking expire date of existing cert..."
-      valid="$("${OPENSSL}" x509 -enddate -noout -in "${cert}" | cut -d= -f2- )"
+      valid="$("${OPENSSL}" x509 -enddate -noout -in "${cert}" | cut -d= -f2-)"
 
       printf " + Valid till %s " "${valid}"
       if ("${OPENSSL}" x509 -checkend $((RENEW_DAYS * 86400)) -noout -in "${cert}" > /dev/null 2>&1); then
@@ -1724,7 +1731,7 @@ command_sign_domains() {
 
       if [[ ! -e "${certdir}/ocsp.der" ]]; then
         update_ocsp="yes"
-      elif ! ("${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respin "${certdir}/ocsp.der" -status_age $((OCSP_DAYS*24*3600)) 2>&1 | grep -q "${cert}: good"); then
+      elif ! ("${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respin "${certdir}/ocsp.der" -status_age $((OCSP_DAYS * 24 * 3600)) 2>&1 | grep -q "${cert}: good"); then
         update_ocsp="yes"
       fi
 
@@ -1907,7 +1914,7 @@ command_cleanup() {
         # Look up current file in use
         current="$(basename "$(readlink "${certdir}/${filetype}")")"
       else
-        if [[ -h "${certdir}/${filetype}" ]]; then
+        if [[ -L "${certdir}/${filetype}" ]]; then
           echo "Removing broken symlink: ${certdir}/${filetype}"
           rm -f "${certdir}/${filetype}"
         fi
@@ -1945,21 +1952,27 @@ command_cleanupdelete() {
   command_cleanup
 }
 
-
 # Usage: --help (-h)
 # Description: Show help text
 command_help() {
   printf "Usage: %s [-h] [command [argument]] [parameter [argument]] [parameter [argument]] ...\n\n" "${0}"
   printf "Default command: help\n\n"
   echo "Commands:"
-  grep -e '^[[:space:]]*# Usage:' -e '^[[:space:]]*# Description:' -e '^command_.*()[[:space:]]*{' "${0}" | while read -r usage; read -r description; read -r command; do
+  grep -e '^[[:space:]]*# Usage:' -e '^[[:space:]]*# Description:' -e '^command_.*()[[:space:]]*{' "${0}" | while
+    read -r usage
+    read -r description
+    read -r command
+  do
     if [[ ! "${usage}" =~ Usage ]] || [[ ! "${description}" =~ Description ]] || [[ ! "${command}" =~ ^command_ ]]; then
       _exiterr "Error generating help text."
     fi
     printf " %-32s %s\n" "${usage##"# Usage: "}" "${description##"# Description: "}"
   done
   printf -- "\nParameters:\n"
-  grep -E -e '^[[:space:]]*# PARAM_Usage:' -e '^[[:space:]]*# PARAM_Description:' "${0}" | while read -r usage; read -r description; do
+  grep -E -e '^[[:space:]]*# PARAM_Usage:' -e '^[[:space:]]*# PARAM_Description:' "${0}" | while
+    read -r usage
+    read -r description
+  do
     if [[ ! "${usage}" =~ Usage ]] || [[ ! "${description}" =~ Description ]]; then
       _exiterr "Error generating help text."
     fi
@@ -1999,18 +2012,18 @@ main() {
   # shellcheck disable=SC2199
   [[ -z "${@}" ]] && eval set -- "--help"
 
-  while (( ${#} )); do
+  while ((${#})); do
     case "${1}" in
-      --help|-h)
+      --help | -h)
         command_help
         exit 0
         ;;
 
-      --env|-e)
+      --env | -e)
         set_command env
         ;;
 
-      --cron|-c)
+      --cron | -c)
         set_command sign_domains
         ;;
 
@@ -2032,14 +2045,14 @@ main() {
         set_command terms
         ;;
 
-      --signcsr|-s)
+      --signcsr | -s)
         shift 1
         set_command sign_csr
         check_parameters "${1:-}"
         PARAM_CSR="${1}"
         ;;
 
-      --revoke|-r)
+      --revoke | -r)
         shift 1
         set_command revoke
         check_parameters "${1:-}"
@@ -2050,47 +2063,47 @@ main() {
         set_command deactivate
         ;;
 
-      --version|-v)
+      --version | -v)
         set_command version
         ;;
 
-      --cleanup|-gc)
+      --cleanup | -gc)
         set_command cleanup
         ;;
 
-      --cleanup-delete|-gcd)
+      --cleanup-delete | -gcd)
         set_command cleanupdelete
         PARAM_CLEANUPDELETE="yes"
         ;;
 
       # PARAM_Usage: --full-chain (-fc)
       # PARAM_Description: Print full chain when using --signcsr
-      --full-chain|-fc)
+      --full-chain | -fc)
         PARAM_FULL_CHAIN="1"
         ;;
 
       # PARAM_Usage: --ipv4 (-4)
       # PARAM_Description: Resolve names to IPv4 addresses only
-      --ipv4|-4)
+      --ipv4 | -4)
         PARAM_IP_VERSION="4"
         ;;
 
       # PARAM_Usage: --ipv6 (-6)
       # PARAM_Description: Resolve names to IPv6 addresses only
-      --ipv6|-6)
+      --ipv6 | -6)
         PARAM_IP_VERSION="6"
         ;;
 
       # PARAM_Usage: --domain (-d) domain.tld
       # PARAM_Description: Use specified domain name(s) instead of domains.txt entry (one certificate!)
-      --domain|-d)
+      --domain | -d)
         shift 1
         check_parameters "${1:-}"
         if [[ -z "${PARAM_DOMAIN:-}" ]]; then
           PARAM_DOMAIN="${1}"
         else
           PARAM_DOMAIN="${PARAM_DOMAIN} ${1}"
-         fi
+        fi
         ;;
 
       # PARAM_Usage: --ca url/preset
@@ -2113,13 +2126,13 @@ main() {
 
       # PARAM_Usage: --keep-going (-g)
       # PARAM_Description: Keep going after encountering an error while creating/renewing multiple certificates in cron mode
-      --keep-going|-g)
+      --keep-going | -g)
         PARAM_KEEP_GOING="yes"
         ;;
 
       # PARAM_Usage: --force (-x)
       # PARAM_Description: Force renew of certificate even if it is longer valid than value in RENEW_DAYS
-      --force|-x)
+      --force | -x)
         PARAM_FORCE="yes"
         ;;
 
@@ -2131,7 +2144,7 @@ main() {
 
       # PARAM_Usage: --no-lock (-n)
       # PARAM_Description: Don't use lockfile (potentially dangerous!)
-      --no-lock|-n)
+      --no-lock | -n)
         PARAM_NO_LOCK="yes"
         ;;
 
@@ -2151,7 +2164,7 @@ main() {
 
       # PARAM_Usage: --privkey (-p) path/to/key.pem
       # PARAM_Description: Use specified private key instead of account key (useful for revocation)
-      --privkey|-p)
+      --privkey | -p)
         shift 1
         check_parameters "${1:-}"
         PARAM_ACCOUNT_KEY="${1}"
@@ -2167,7 +2180,7 @@ main() {
 
       # PARAM_Usage: --config (-f) path/to/config
       # PARAM_Description: Use specified config file
-      --config|-f)
+      --config | -f)
         shift 1
         check_parameters "${1:-}"
         CONFIG="${1}"
@@ -2175,7 +2188,7 @@ main() {
 
       # PARAM_Usage: --hook (-k) path/to/hook.sh
       # PARAM_Description: Use specified script for hooks
-      --hook|-k)
+      --hook | -k)
         shift 1
         check_parameters "${1:-}"
         PARAM_HOOK="${1}"
@@ -2191,7 +2204,7 @@ main() {
 
       # PARAM_Usage: --out (-o) certs/directory
       # PARAM_Description: Output certificates into the specified directory
-      --out|-o)
+      --out | -o)
         shift 1
         check_parameters "${1:-}"
         PARAM_CERTDIR="${1}"
@@ -2207,7 +2220,7 @@ main() {
 
       # PARAM_Usage: --challenge (-t) http-01|dns-01|tls-alpn-01
       # PARAM_Description: Which challenge should be used? Currently http-01, dns-01, and tls-alpn-01 are supported
-      --challenge|-t)
+      --challenge | -t)
         shift 1
         check_parameters "${1:-}"
         PARAM_CHALLENGETYPE="${1}"
@@ -2215,7 +2228,7 @@ main() {
 
       # PARAM_Usage: --algo (-a) rsa|prime256v1|secp384r1
       # PARAM_Description: Which public key algorithm should be used? Supported: rsa, prime256v1 and secp384r1
-      --algo|-a)
+      --algo | -a)
         shift 1
         check_parameters "${1:-}"
         PARAM_KEY_ALGO="${1}"
@@ -2232,18 +2245,21 @@ main() {
   done
 
   case "${COMMAND}" in
-    env) command_env;;
-    sign_domains) command_sign_domains;;
-    register) command_register;;
-    account) command_account;;
-    sign_csr) command_sign_csr "${PARAM_CSR}";;
-    revoke) command_revoke "${PARAM_REVOKECERT}";;
-    deactivate) command_deactivate;;
-    cleanup) command_cleanup;;
-    terms) command_terms;;
-    cleanupdelete) command_cleanupdelete;;
-    version) command_version;;
-    *) command_help; exit 1;;
+    env) command_env ;;
+    sign_domains) command_sign_domains ;;
+    register) command_register ;;
+    account) command_account ;;
+    sign_csr) command_sign_csr "${PARAM_CSR}" ;;
+    revoke) command_revoke "${PARAM_REVOKECERT}" ;;
+    deactivate) command_deactivate ;;
+    cleanup) command_cleanup ;;
+    terms) command_terms ;;
+    cleanupdelete) command_cleanupdelete ;;
+    version) command_version ;;
+    *)
+      command_help
+      exit 1
+      ;;
   esac
 
   exit "${exit_with_errorcode}"

--- a/n_utils/includes/nexus_tools.sh
+++ b/n_utils/includes/nexus_tools.sh
@@ -16,7 +16,7 @@
 
 source "$(n-include common_tools.sh)"
 
-configure_and_start_nexus () {
+configure_and_start_nexus() {
   check_parameters CF_paramDnsName CF_paramSonatypeWorkSize
   ndt volume-from-snapshot --gp3 nexus-data nexus-data /opt/nexus/sonatype-work ${CF_paramSonatypeWorkSize}
   chown -R nexus:nexus /opt/nexus/sonatype-work
@@ -50,7 +50,7 @@ configure_and_start_nexus () {
   systemctl enable nexus
   systemctl start nexus
 }
-configure_and_start_nexus3 () {
+configure_and_start_nexus3() {
   ndt volume-from-snapshot --gp3 nexus-data nexus-data /opt/nexus/sonatype-work ${CF_paramSonatypeWorkSize}
   chown -R nexus:nexus /opt/nexus/sonatype-work
   if ! [ -d /opt/nexus/sonatype-work/nexus3 ]; then
@@ -60,7 +60,7 @@ configure_and_start_nexus3 () {
   systemctl enable nexus
   systemctl start nexus
 }
-nexus_wait_service_up () {
+nexus_wait_service_up() {
   # Tests to see if everything is OK
   COUNT=0
   while [ $COUNT -lt 300 ] && [ "$SERVER" != "Sonatype" ]; do
@@ -84,7 +84,7 @@ nexus3_wait_service_up() {
   fi
 }
 
-nexus_setup_snapshot_cron () {
+nexus_setup_snapshot_cron() {
   cat > /etc/cron.d/home-snapshot << MARKER
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin

--- a/n_utils/includes/openvpn_tools.sh
+++ b/n_utils/includes/openvpn_tools.sh
@@ -14,22 +14,22 @@ openvpn_install_easyrsa() {
   tar -xzvf easy-rsa.tgz --strip-components=1 --directory /etc/openvpn/easy-rsa
   rm -f easy-rsa.tgz.sig easy-rsa.tgz
   cd /etc/openvpn/easy-rsa/ || return
-  echo "set_var EASYRSA_ALGO ec" >vars
-  echo "set_var EASYRSA_CURVE prime256v1" >>vars
+  echo "set_var EASYRSA_ALGO ec" > vars
+  echo "set_var EASYRSA_CURVE prime256v1" >> vars
   fetch-secrets.sh get 500 --optional /etc/openvpn/easy-rsa/${CF_paramDnsName}-easyrsa-keys.sh
   if [ -x /etc/openvpn/easy-rsa/${CF_paramDnsName}-easyrsa-keys.sh ]; then
     /etc/openvpn/easy-rsa/${CF_paramDnsName}-easyrsa-keys.sh
     SERVER_NAME=$(cat SERVER_NAME_GENERATED)
     SERVER_CN=$(cat SERVER_CN_GENERATED)
-    echo "set_var EASYRSA_REQ_CN $SERVER_CN" >>vars
+    echo "set_var EASYRSA_REQ_CN $SERVER_CN" >> vars
   else
     # Generate a random, alphanumeric identifier of 16 characters for CN and one for server name
     SERVER_CN="cn_$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)"
-    echo "$SERVER_CN" >SERVER_CN_GENERATED
+    echo "$SERVER_CN" > SERVER_CN_GENERATED
     SERVER_NAME="server_$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)"
-    echo "$SERVER_NAME" >SERVER_NAME_GENERATED
+    echo "$SERVER_NAME" > SERVER_NAME_GENERATED
 
-    echo "set_var EASYRSA_REQ_CN $SERVER_CN" >>vars
+    echo "set_var EASYRSA_REQ_CN $SERVER_CN" >> vars
 
     # Create the PKI, set up the CA, the DH params and the server certificate
     ./easyrsa init-pki
@@ -106,7 +106,7 @@ EOF
   sed -ne 's/^nameserver[[:space:]]\+\([^[:space:]]\+\).*$/\1/p' $RESOLVCONF | while read -r line; do
     # Copy, if it's a IPv4
     if [[ $line =~ ^[0-9.]*$ ]]; then
-      echo "push \"dhcp-option DNS $line\"" >>/etc/openvpn/server.conf
+      echo "push \"dhcp-option DNS $line\"" >> /etc/openvpn/server.conf
     fi
   done
   # Create client-config-dir dir
@@ -115,7 +115,7 @@ EOF
   mkdir -p /var/log/openvpn
 
   # Enable routing
-  echo 'net.ipv4.ip_forward=1' >/etc/sysctl.d/99-openvpn.conf
+  echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-openvpn.conf
   sysctl --system
 
   source /etc/os-release
@@ -233,12 +233,12 @@ function openvpn_add_route() {
   echo "push \"route $ADDR $NETMASK\"" >> /etc/openvpn/server.conf
 }
 function openvpn_add_domain() {
-  echo "push \"dhcp-option DOMAIN $1\""  >> /etc/openvpn/server.conf
+  echo "push \"dhcp-option DOMAIN $1\"" >> /etc/openvpn/server.conf
 }
 function openvpn_new_client() {
   local CLIENT=$1
   cd /etc/openvpn/easy-rsa/ || return
-    ./easyrsa build-client-full "$CLIENT" nopass
+  ./easyrsa build-client-full "$CLIENT" nopass
   echo "Client $CLIENT added."
 
   homeDir="/root"
@@ -258,10 +258,10 @@ function openvpn_new_client() {
     cat "/etc/openvpn/easy-rsa/pki/private/$CLIENT.key"
     echo "</key>"
 
-      echo "<tls-crypt>"
-      cat /etc/openvpn/tls-crypt.key
-      echo "</tls-crypt>"
-  } >>"$homeDir/$CLIENT.ovpn"
+    echo "<tls-crypt>"
+    cat /etc/openvpn/tls-crypt.key
+    echo "</tls-crypt>"
+  } >> "$homeDir/$CLIENT.ovpn"
 
   echo ""
   echo "The configuration file has been written to $homeDir/$CLIENT.ovpn."

--- a/n_utils/includes/prepare.sh
+++ b/n_utils/includes/prepare.sh
@@ -1,5 +1,5 @@
 #/bin/bash -x
 if ! grep -e 'secure_path.*/usr/local/bin' /etc/sudoers > /dev/null; then
-    sed -i 's/\(.*secure_path.*\)/\1:\/usr\/local\/bin/' /etc/sudoers
+  sed -i 's/\(.*secure_path.*\)/\1:\/usr\/local\/bin/' /etc/sudoers
 fi
 exit 0

--- a/n_utils/includes/print-create-instructions.sh
+++ b/n_utils/includes/print-create-instructions.sh
@@ -4,10 +4,10 @@ if [ "$_ARGCOMPLETE" ]; then
   unset _ARGCOMPLETE
   source $(n-include autocomplete-helpers.sh)
   # Handle command completion executions
-  COMP_WORDS=( $COMP_LINE )
+  COMP_WORDS=($COMP_LINE)
   IMAGE_DIR=${COMP_WORDS[2]}
   STACK=${COMP_WORDS[3]}
-  IMAGE=$(echo $IMAGE_DIR| tr "-" "_")
+  IMAGE=$(echo $IMAGE_DIR | tr "-" "_")
   case $COMP_CWORD in
     2)
       compgen -W "$(get_stack_dirs)" -- $COMP_CUR

--- a/n_utils/includes/ssh_tools.sh
+++ b/n_utils/includes/ssh_tools.sh
@@ -16,7 +16,7 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common_tools.sh"
 
-ssh_install_hostkeys () {
+ssh_install_hostkeys() {
   check_parameters CF_paramDnsName
   fetch-secrets.sh get 500 --optional /etc/ssh/${CF_paramDnsName}-ssh-hostkeys.sh
   if [ -x /etc/ssh/${CF_paramDnsName}-ssh-hostkeys.sh ]; then
@@ -27,13 +27,13 @@ ssh_install_hostkeys () {
   fi
 }
 
-ssh_restart_service () {
+ssh_restart_service() {
   sed -i 's/^#PermitRootLogin.*$/PermitRootLogin no/g' /etc/ssh/sshd_config
-  case  "$SYSTEM_TYPE" in
+  case "$SYSTEM_TYPE" in
     ubuntu)
       service ssh restart
       ;;
-    centos|rhel|rocky|fedora)
+    centos | rhel | rocky | fedora)
       systemctl restart sshd
       ;;
     *)

--- a/n_utils/includes/store-secret-lpass.sh
+++ b/n_utils/includes/store-secret-lpass.sh
@@ -18,8 +18,7 @@
 [ "$CF_paramSecretsFolder" ] || CF_paramSecretsFolder="$(ndt cf-get-parameter paramSecretsFolder)"
 [ "$CF_paramSecretsUser" ] || CF_paramSecretsUser="$(ndt cf-get-parameter paramSecretsUser)"
 
-
-login_if_not_already () {
+login_if_not_already() {
   if ! lpass ls not-meant-to-return-anything > /dev/null 2>&1; then
     export AWS_DEFAULT_REGION=$(ndt ec2-region)
     aws s3 s3://${CF_paramSecretsBucket}/webmaster.pwd - | $(n-include lastpass-login.sh) ${CF_paramSecretsUser} -

--- a/n_utils/includes/template-snippets/assume-deploy-role.sh
+++ b/n_utils/includes/template-snippets/assume-deploy-role.sh
@@ -19,7 +19,6 @@ set -e
 CF_paramBakeRoleStack="bakery-roles"
 CF_AWS__Region="eu-west-1"
 
-
 if [ -n "$DEPLOY_ROLE_ARN" ]; then
   ROLE_ARN="$DEPLOY_ROLE_ARN"
 else

--- a/n_utils/includes/terraform-pull-state.sh
+++ b/n_utils/includes/terraform-pull-state.sh
@@ -44,7 +44,7 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -54,26 +54,28 @@ usage() {
 if [ "$1" = "--help" -o "$1" = "-h" ]; then
   usage
 fi
-die () {
+die() {
   echo "$1" >&4
   usage
 }
 onexit() {
-    EXIT_VAL=$?
-    if [ "$EXIT_VAL" != "0" ]; then
-        cat $TF_INIT_OUTPUT >&4
-    fi
-    rm -f $OUTPUT
-    exit "$EXIT_VAL"
+  EXIT_VAL=$?
+  if [ "$EXIT_VAL" != "0" ]; then
+    cat $TF_INIT_OUTPUT >&4
+  fi
+  rm -f $OUTPUT
+  exit "$EXIT_VAL"
 }
 export TF_INIT_OUTPUT="$(mktemp)"
-exec 3>&1 4>&2 >$TF_INIT_OUTPUT 2>&1
+exec 3>&1 4>&2 > $TF_INIT_OUTPUT 2>&1
 trap onexit EXIT
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-terraform="$1"; shift
+terraform="$1"
+shift
 [ "${terraform}" ] || die "You must give the terraform name as argument"
 
 eval "$(ndt load-parameters "$component" -t "$terraform" -e -r)"

--- a/n_utils/includes/tool_installers.sh
+++ b/n_utils/includes/tool_installers.sh
@@ -54,7 +54,7 @@ if [ -z "$GITHUB_RUNNER_VERSION" ]; then
 fi
 
 # Make sure we get logging
-if ! grep cloud-init-output.log /etc/cloud/cloud.cfg.d/05_logging.cfg > /dev/null ; then
+if ! grep cloud-init-output.log /etc/cloud/cloud.cfg.d/05_logging.cfg > /dev/null; then
   echo "output: {all: '| tee -a /var/log/cloud-init-output.log'}" >> /etc/cloud/cloud.cfg.d/05_logging.cfg
 fi
 
@@ -202,7 +202,7 @@ update_deploytools() {
   echo "Updating nameless-deploy-tools to $DEPLOYTOOLS_VERSION"
   bash "$(n-include install_tools.sh)" "${DEPLOYTOOLS_VERSION}"
 }
-update_aws_utils () {
+update_aws_utils() {
   echo "###########################"
   echo "#        DEPRECATED       #"
   echo "###########################"
@@ -213,16 +213,17 @@ update_aws_utils () {
 install_dynatrace_oneagent() {
   # Requires secrets dynatrace.apikey and dt-root.cert.pem (from dynatrace web installation instructions) to be stored in secrets storage
   wget -O Dynatrace-OneAgent-Linux-$ONEAGENT_VERSION.sh \
-  "https://bmq38893.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=x86&flavor=default" \
-  --header="Authorization: Api-Token $(fetch-secrets.sh show dynatrace.apikey)"
+    "https://bmq38893.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=x86&flavor=default" \
+    --header="Authorization: Api-Token $(fetch-secrets.sh show dynatrace.apikey)"
 
   fetch-secrets.sh get 400 dt-root.cert.pem
-  ( echo 'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="--SIGNED-INSTALLER"'
+  (
+    echo 'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="--SIGNED-INSTALLER"'
     echo
     echo
     echo '----SIGNED-INSTALLER'
-    cat Dynatrace-OneAgent-Linux-$ONEAGENT_VERSION.sh ) | \
-  openssl cms -verify -CAfile dt-root.cert.pem > /dev/null
+    cat Dynatrace-OneAgent-Linux-$ONEAGENT_VERSION.sh
+  ) | openssl cms -verify -CAfile dt-root.cert.pem > /dev/null
   rm -f dt-root.cert.pem
 
   /bin/sh Dynatrace-OneAgent-Linux-$ONEAGENT_VERSION.sh
@@ -236,12 +237,13 @@ install_dynatrace_activegate() {
     --header="Authorization: Api-Token $(fetch-secrets.sh show dynatrace.apikey)"
 
   fetch-secrets.sh get 400 dt-root.cert.pem
-  ( echo 'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="--SIGNED-INSTALLER"'
+  (
+    echo 'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="--SIGNED-INSTALLER"'
     echo
     echo
     echo '----SIGNED-INSTALLER'
-    cat  Dynatrace-ActiveGate-Linux-x86-$ACTIVEGATE_VERSION.sh ) | \
-  openssl cms -verify -CAfile dt-root.cert.pem > /dev/null
+    cat Dynatrace-ActiveGate-Linux-x86-$ACTIVEGATE_VERSION.sh
+  ) | openssl cms -verify -CAfile dt-root.cert.pem > /dev/null
   rm -f dt-root.cert.pem
 
   /bin/sh Dynatrace-ActiveGate-Linux-x86-$ACTIVEGATE_VERSION.sh
@@ -265,7 +267,7 @@ install_androidsdk() {
   unzip -d /opt/android platform-tools-linux.zip
   rm -f commandlinetools-linux_latest.zip platform-tools-linux.zip
   mkdir /opt/android/cmdline-tools/latest
-  mv /opt/android/cmdline-tools/* /opt/android/cmdline-tools/latest ||:
+  mv /opt/android/cmdline-tools/* /opt/android/cmdline-tools/latest || :
   cat > /etc/profile.d/android.sh << MARKER
 export PATH="\$PATH:/opt/android/platform-tools:/opt/android/cmdline-tools/latest/bin"
 MARKER
@@ -287,7 +289,7 @@ MARKER
   flutter precache
   yes | flutter doctor --android-licenses
 }
-install_github_actions_runner(){
+install_github_actions_runner() {
   source $(n-include common_tools.sh)
   mkdir /opt/github-runner
   safe_download https://github.com/actions/runner/releases/download/v$GITHUB_RUNNER_VERSION/actions-runner-linux-x64-$GITHUB_RUNNER_VERSION.tar.gz $GITHUB_RUNNER_CSUM actions-runner-linux-x64.tar.gz
@@ -295,27 +297,27 @@ install_github_actions_runner(){
   rm -f actions-runner-linux-x64.tar.gz
   /opt/github-runner/bin/installdependencies.sh
 }
-start_github_actions_runner(){
- local LOCAL_USER=$1
- local URL_TARGET=$2
- local TOKEN=$3
- chown -R $LOCAL_USER /opt/github-runner
- pushd /opt/github-runner 
- sudo -u $LOCAL_USER bash -c "./config.sh --unattended --url $URL_TARGET --token $TOKEN --replace"
- /opt/github-runner/svc.sh install $LOCAL_USER
- /opt/github-runner/svc.sh start
- popd
+start_github_actions_runner() {
+  local LOCAL_USER=$1
+  local URL_TARGET=$2
+  local TOKEN=$3
+  chown -R $LOCAL_USER /opt/github-runner
+  pushd /opt/github-runner
+  sudo -u $LOCAL_USER bash -c "./config.sh --unattended --url $URL_TARGET --token $TOKEN --replace"
+  /opt/github-runner/svc.sh install $LOCAL_USER
+  /opt/github-runner/svc.sh start
+  popd
 }
 # requires PAT-TOKEN with write-access to org self hosted runner endpoints
 # https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#organization-self-hosted-runners
 # NOTE: create a fine-grained solely for this purpose
-github_actions_get_create_token(){
+github_actions_get_create_token() {
   local PAT_TOKEN=$1
   local ORGANIZATION=$2
   echo $(curl -sL \
-  -X POST \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer $PAT_TOKEN"\
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/orgs/$ORGANIZATION/actions/runners/registration-token | jq -r .token)
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $PAT_TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/orgs/$ORGANIZATION/actions/runners/registration-token | jq -r .token)
 }

--- a/n_utils/includes/undeploy-azure.sh
+++ b/n_utils/includes/undeploy-azure.sh
@@ -48,9 +48,9 @@ usage() {
   echo "                  you would give blobstore" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and azure cli what-if operation"  >&2
-  echo "  -v, --verbose verbose - verbose output from azure cli"  >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -d, --dryrun  dry-run - do only parameter expansion and template pre-processing and azure cli what-if operation" >&2
+  echo "  -v, --verbose verbose - verbose output from azure cli" >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -69,16 +69,18 @@ while [ "$1" = "-d" -o "$1" = "--dryrun" -o "$1" = "-v" -o "$1" = "--verbose" ];
     shift
   fi
 done
-die () {
+die() {
   set +x
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-azure="$1"; shift
+azure="$1"
+shift
 [ "${azure}" ] || die "You must give the azure name as argument"
 
 eval "$(ndt load-parameters "$component" -a "$azure" -e -r)"

--- a/n_utils/includes/undeploy-cdk.sh
+++ b/n_utils/includes/undeploy-cdk.sh
@@ -45,7 +45,7 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -55,15 +55,17 @@ usage() {
 if [ "$1" = "--help" -o "$1" = "-h" ]; then
   usage
 fi
-die () {
+die() {
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-cdk="$1"; shift
+cdk="$1"
+shift
 [ "${cdk}" ] || die "You must give the cdk name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)

--- a/n_utils/includes/undeploy-serverless.sh
+++ b/n_utils/includes/undeploy-serverless.sh
@@ -45,7 +45,7 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -55,15 +55,17 @@ usage() {
 if [ "$1" = "--help" -o "$1" = "-h" ]; then
   usage
 fi
-die () {
+die() {
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-serverless="$1"; shift
+serverless="$1"
+shift
 [ "${serverless}" ] || die "You must give the serverless name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)

--- a/n_utils/includes/undeploy-terraform.sh
+++ b/n_utils/includes/undeploy-terraform.sh
@@ -45,7 +45,7 @@ usage() {
   echo "                  you would give sender" >&2
   echo "" >&2
   echo "optional arguments:" >&2
-  echo "  -h, --help    show this help message and exit"  >&2
+  echo "  -h, --help    show this help message and exit" >&2
   if "$@"; then
     echo "" >&2
     echo "$@" >&2
@@ -55,15 +55,17 @@ usage() {
 if [ "$1" = "--help" -o "$1" = "-h" ]; then
   usage
 fi
-die () {
+die() {
   echo "$1" >&2
   usage
 }
 set -xe
 
-component="$1" ; shift
+component="$1"
+shift
 [ "${component}" ] || die "You must give the component name as argument"
-terraform="$1"; shift
+terraform="$1"
+shift
 [ "${terraform}" ] || die "You must give the terraform name as argument"
 
 TSTAMP=$(date +%Y%m%d%H%M%S)

--- a/release.sh
+++ b/release.sh
@@ -16,40 +16,40 @@
 
 # Check platform
 case "$(uname -s)" in
-    "Darwin")
-        PLATFORM="mac"
-        ;;
-    "MINGW"*)
-        PLATFORM="windows"
-        ;;
-    *)
-        PLATFORM="linux"
-        ;;
+  "Darwin")
+    PLATFORM="mac"
+    ;;
+  "MINGW"*)
+    PLATFORM="windows"
+    ;;
+  *)
+    PLATFORM="linux"
+    ;;
 esac
 
 # BSD sed on MacOS works differently
 if [ "$PLATFORM" = mac ]; then
-    SED_COMMAND=(sed -i '')
+  SED_COMMAND=(sed -i '')
 else
-    SED_COMMAND=(sed -i)
+  SED_COMMAND=(sed -i)
 fi
 
 VERSION=$(grep -E '^VERSION' n_utils/__init__.py | cut -d\" -f 2)
 MAJOR=${VERSION//.*/}
 MINOR=${VERSION##*.}
 if [ "$1" = "-m" ]; then
-    MAJOR=$(($MAJOR + 1))
-    MINOR="0"
-    NEW_VERSION=$MAJOR.$MINOR
-    shift
+  MAJOR=$(($MAJOR + 1))
+  MINOR="0"
+  NEW_VERSION=$MAJOR.$MINOR
+  shift
 elif [ "$1" = "-v" ]; then
-    shift
-    NEW_VERSION="$1"
-    shift
+  shift
+  NEW_VERSION="$1"
+  shift
 else
-    MINOR=$(($MINOR + 1))
-    NEW_VERSION=$MAJOR.$MINOR
-    MESSAGE="$1"
+  MINOR=$(($MINOR + 1))
+  NEW_VERSION=$MAJOR.$MINOR
+  MESSAGE="$1"
 fi
 
 if [ -z "$MESSAGE" ]; then
@@ -68,16 +68,16 @@ git tag "$NEW_VERSION" -m "$MESSAGE"
 git push origin "$NEW_VERSION"
 
 if [ -n "$(command -v python3)" ]; then
-    PYTHON=$(which python3)
+  PYTHON=$(which python3)
 else
-    PYTHON=$(which python)
+  PYTHON=$(which python)
 fi
 
 if [ ! -e "$PYTHON" ]; then
-    echo "Python executable not found: $PYTHON"
-    exit 1
+  echo "Python executable not found: $PYTHON"
+  exit 1
 else
-    echo "Using $PYTHON $($PYTHON --version)"
+  echo "Using $PYTHON $($PYTHON --version)"
 fi
 
 rm -rf dist/*


### PR DESCRIPTION
- Add `.editorconfig` with shell formatting settings
- Run [shfmt](https://github.com/mvdan/sh) for all shell files: `shfmt --write **/*.sh`

Mostly whitespace fixes...

I personally prefer indenting with 4 spaces, especially in Python codebases since Python uses 4 spaces so having everything use 4 spaces is simpler and more consistent. However, most of the shell scripts here where using 2 spaces so went with that.