### PR TITLE
C++ improvements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+﻿# Config for C++ code formatting
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+BasedOnStyle: WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: DontAlign
+AlignOperands: DontAlign
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: MultiLine
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 120
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+InsertBraces: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 20000
+PointerAlignment: Left
+SortIncludes: CaseInsensitive
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++20
+TabWidth: 4
+UseTab: Never
+...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+[*.sh]
+# see `man shfmt` for explanations
+binary_next_line = false
+function_next_line = false
+indent_size = 2
+indent_style = space
+keep_padding = true
+shell_variant = bash
+space_redirects = true
+switch_case_indent = true
+
+# Ignore the entire "third_party" directory.
+[third_party/**]
+ignore = true

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ You need to have AWS credentials for command line access set up.
 
 For full list of commands see [here](docs/commands.md)
 
-You can additionally use a faster register-complete by running `faster_register_complete.sh`. This compiles a C++ program from the file `nameless-dt-register-complete.cpp` and replaces the python-version of `nameless-dt-register-complete` with it.
+You can additionally use a faster register-complete by running `faster_register_complete.sh`.
+This compiles a C++ program from the file `nameless-dt-register-complete.cpp`,
+and replaces the Python version of `nameless-dt-register-complete` with it.
+
 ## Documentation
 
 * [Command Reference](docs/commands.md)

--- a/faster_register_complete.sh
+++ b/faster_register_complete.sh
@@ -1,1 +1,59 @@
-g++ -std=c++11 -O2 n_utils/nameless-dt-register-complete.cpp -o $(dirname $(which python))/nameless-dt-register-complete
+#!/bin/bash
+set -eo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Check platform
+case "$(uname -s)" in
+"Darwin")
+  PLATFORM="mac"
+  ;;
+"MINGW"*)
+  PLATFORM="windows"
+  ;;
+*)
+  PLATFORM="linux"
+  ;;
+esac
+
+if [ -n "$(command -v python3)" ]; then
+  PYTHON=$(which python3)
+else
+  PYTHON=$(which python)
+fi
+
+if [ ! -e "$PYTHON" ]; then
+  echo "Python executable not found: $PYTHON"
+  exit 1
+else
+  echo "Using $PYTHON $($PYTHON --version)"
+fi
+
+ARGS=(-std=c++20 -O3 -Wall -Wextra)
+if [ "$PLATFORM" = mac ]; then
+  # 03/2023:
+  # try to use brew llvm / Clang since it is newer than what Apple includes.
+  # Critically, Clang 14 does not yet support `march` compiler option for Apple Silicon,
+  # but brew llvm comes with Clang 15 that does support it so we can get the full benefit from the C++ code.
+  # This can be removed once macOS comes with Clang 15 by default...
+  if [ -e "$(brew --prefix)/opt/llvm/bin/clang++" ]; then
+    COMPILER="$(brew --prefix)/opt/llvm/bin/clang++"
+    ARGS+=(-march=native -mtune=native)
+  else
+    COMPILER="g++"
+  fi
+else
+  COMPILER="g++"
+  ARGS+=(-march=native -mtune=native)
+fi
+
+ARGS+=("$REPO_ROOT/n_utils/nameless-dt-register-complete.cpp" -o "$(dirname "$PYTHON")/nameless-dt-register-complete")
+
+if [ -z "$(command -v "$COMPILER")" ]; then
+  echo "Compiler not found: $COMPILER"
+  exit 1
+fi
+
+echo "Running: $COMPILER ${ARGS[*]}"
+$COMPILER --version
+$COMPILER "${ARGS[@]}"

--- a/faster_register_complete.sh
+++ b/faster_register_complete.sh
@@ -16,19 +16,6 @@ case "$(uname -s)" in
     ;;
 esac
 
-if [ -n "$(command -v python3)" ]; then
-  PYTHON=$(which python3)
-else
-  PYTHON=$(which python)
-fi
-
-if [ ! -e "$PYTHON" ]; then
-  echo "Python executable not found: $PYTHON"
-  exit 1
-else
-  echo "Using $PYTHON $($PYTHON --version)"
-fi
-
 ARGS=(-std=c++20 -O3 -Wall -Wextra)
 if [ "$PLATFORM" = mac ]; then
   # 03/2023:
@@ -47,7 +34,27 @@ else
   ARGS+=(-march=native -mtune=native)
 fi
 
-ARGS+=("$REPO_ROOT/n_utils/nameless-dt-register-complete.cpp" -o "$(dirname "$PYTHON")/nameless-dt-register-complete")
+if [ -n "$(command -v nameless-dt-register-complete)" ]; then
+  echo "Overwriting existing script"
+  DESTINATION="$(which nameless-dt-register-complete)"
+else
+  if [ -n "$(command -v python3)" ]; then
+    PYTHON=$(which python3)
+  else
+    PYTHON=$(which python)
+  fi
+
+  if [ ! -e "$PYTHON" ]; then
+    echo "Python executable not found: $PYTHON"
+    exit 1
+  else
+    echo "$($PYTHON --version) from $PYTHON"
+  fi
+
+  DESTINATION="$(dirname "$PYTHON")/nameless-dt-register-complete"
+fi
+
+ARGS+=("$REPO_ROOT/n_utils/nameless-dt-register-complete.cpp" -o "$DESTINATION")
 
 if [ -z "$(command -v "$COMPILER")" ]; then
   echo "Compiler not found: $COMPILER"

--- a/faster_register_complete.sh
+++ b/faster_register_complete.sh
@@ -5,15 +5,15 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Check platform
 case "$(uname -s)" in
-"Darwin")
-  PLATFORM="mac"
-  ;;
-"MINGW"*)
-  PLATFORM="windows"
-  ;;
-*)
-  PLATFORM="linux"
-  ;;
+  "Darwin")
+    PLATFORM="mac"
+    ;;
+  "MINGW"*)
+    PLATFORM="windows"
+    ;;
+  *)
+    PLATFORM="linux"
+    ;;
 esac
 
 if [ -n "$(command -v python3)" ]; then

--- a/n_utils/nameless-dt-register-complete.cpp
+++ b/n_utils/nameless-dt-register-complete.cpp
@@ -1,6 +1,5 @@
-#include <string.h>
-
 #include <iostream>
+#include <string.h>
 
 const std::string base_str = R"delimiter(_ndt_complete() {
     local IFS=$'\013'
@@ -11,16 +10,16 @@ const std::string base_str = R"delimiter(_ndt_complete() {
         SUPPRESS_SPACE=1
     fi
     COMPREPLY=( $(IFS="$IFS" \
-                  COMP_LINE="$COMP_LINE" \
-                  COMP_POINT="$COMP_POINT" \
-                  COMP_TYPE="$COMP_TYPE" \
-                  COMP_CUR="$COMP_CUR" \
-                  COMP_PREV="$COMP_PREV" \
-                  COMP_CWORD=$COMP_CWORD \
-                  _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
-                  _ARGCOMPLETE=1 \
-                  _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
-                  "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
+        COMP_LINE="$COMP_LINE" \
+        COMP_POINT="$COMP_POINT" \
+        COMP_TYPE="$COMP_TYPE" \
+        COMP_CUR="$COMP_CUR" \
+        COMP_PREV="$COMP_PREV" \
+        COMP_CWORD=$COMP_CWORD \
+        _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
+        _ARGCOMPLETE=1 \
+        _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
+        "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
     elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
@@ -29,15 +28,17 @@ const std::string base_str = R"delimiter(_ndt_complete() {
 }
 complete -o nospace -F _ndt_complete "ndt"
 )delimiter";
+
 const std::string project_env_str = R"delimiter(_projectenv_hook() {
-  local previous_exit_status=$?;
-  eval "$(nameless-dt-load-project-env)";
-  return $previous_exit_status;
+    local previous_exit_status=$?;
+    eval "$(nameless-dt-load-project-env)";
+    return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _projectenv_hook ]]; then
-  PROMPT_COMMAND="_projectenv_hook;$PROMPT_COMMAND";
+    PROMPT_COMMAND="_projectenv_hook;$PROMPT_COMMAND";
 fi
 )delimiter";
+
 const std::string nep_complete_str = R"delimiter(_nep_complete() {
     COMPREPLY=( $(ndt print-aws-profiles "${COMP_WORDS[COMP_CWORD]}" ) )
 }
@@ -52,16 +53,18 @@ nep() {
 
 complete -F _nep_complete nep
 )delimiter";
-int main(int argc, char *argv[]) {
-  std::cout << base_str << std::endl;
-  if (argc > 1) {
-    for (uint32_t i = 1; i < argc; ++i) {
-      if (!strcmp(argv[i], "--project-env")) {
-        std::cout << project_env_str << std::endl;
-      }
-      if (!strcmp(argv[i], "--nep-function")) {
-        std::cout << nep_complete_str << std::endl;
-      }
+
+int main(int argc, char* argv[])
+{
+    std::cout << base_str << std::endl;
+    if (argc > 1) {
+        for (auto i = 1; i < argc; ++i) {
+            if (!strcmp(argv[i], "--project-env")) {
+                std::cout << project_env_str << std::endl;
+            }
+            if (!strcmp(argv[i], "--nep-function")) {
+                std::cout << nep_complete_str << std::endl;
+            }
+        }
     }
-  }
 }

--- a/n_utils/project_util.py
+++ b/n_utils/project_util.py
@@ -138,23 +138,23 @@ def ndt_register_complete():
     local COMP_PREV="${COMP_WORDS[COMP_CWORD-1]}"
     local SUPPRESS_SPACE=0
     if compopt +o nospace 2> /dev/null; then
-        SUPPRESS_SPACE=1
+      SUPPRESS_SPACE=1
     fi
     COMPREPLY=( $(IFS="$IFS" \\
-                  COMP_LINE="$COMP_LINE" \\
-                  COMP_POINT="$COMP_POINT" \\
-                  COMP_TYPE="$COMP_TYPE" \\
-                  COMP_CUR="$COMP_CUR" \\
-                  COMP_PREV="$COMP_PREV" \\
-                  COMP_CWORD=$COMP_CWORD \\
-                  _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \\
-                  _ARGCOMPLETE=1 \\
-                  _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \\
-                  "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
+      COMP_LINE="$COMP_LINE" \\
+      COMP_POINT="$COMP_POINT" \\
+      COMP_TYPE="$COMP_TYPE" \\
+      COMP_CUR="$COMP_CUR" \\
+      COMP_PREV="$COMP_PREV" \\
+      COMP_CWORD=$COMP_CWORD \\
+      _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \\
+      _ARGCOMPLETE=1 \\
+      _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \\
+      "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
     if [[ $? != 0 ]]; then
-        unset COMPREPLY
+      unset COMPREPLY
     elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
-        compopt -o nospace
+      compopt -o nospace
     fi
 }
 complete -o nospace -F _ndt_complete "ndt"


### PR DESCRIPTION
Noticed this thing, added a few tweaks 😉 

- Fix output location (I use pyenv, so output went to wrong place and did not overwrite the python version)
- Use full optimizations, with a workaround for Apple Silicon with Clang 14 that Apple still ships by default (if the point of this is speed, then lets have all the benefits the compiler can give 🤓 )
- Add clang-format config and format code
- Fix compiler warnings

Raised the C++ standard to C++20, which is the default in Clang 15 for example (gcc 12 defaults to C++17). This might cause issues with very old gcc versions but I guess this would be mostly used by developers locally so should not be an issue (_C++20 features are available since GCC 8_).


```console
➜  nameless-deploy-tools git:(cpp-improvements) ✗ ./faster_register_complete.sh
Overwriting existing script
Running: /opt/homebrew/opt/llvm/bin/clang++ -std=c++20 -O3 -Wall -Wextra -march=native -mtune=native /Users/akseli/Developer/nameless-deploy-tools/n_utils/nameless-dt-register-complete.cpp -o /opt/homebrew/bin/nameless-dt-register-complete
Homebrew clang version 15.0.7
Target: arm64-apple-darwin22.3.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm/bin
```