### PR TITLE
add rust toolchain install function

### DIFF
--- a/n_utils/includes/common_tools.sh
+++ b/n_utils/includes/common_tools.sh
@@ -95,10 +95,13 @@ allow_authorizedkeyscommand() {
 }
 
 safe_download() {
-  url="$1"
-  csum="$2"
-  out="$3"
-
+  if [ $# -ne 3 ]; then
+    echo "Error: safe_download takes three arguments: <url> <checksum> <output_file>"
+    exit 1
+  fi
+  local url="$1"
+  local csum="$2"
+  local out="$3"
   wget --no-verbose --output-document="$out" "$url"
   echo "$csum  $out" | sha256sum --check
 }

--- a/n_utils/includes/install_tools.sh
+++ b/n_utils/includes/install_tools.sh
@@ -60,7 +60,7 @@ gpg_safe_download() {
   gpg --verify $DST.sig $DST
 }
 
-function install_awscliv2() {
+install_awscliv2() {
   AWS_CLI_INSTALL_DIR=$(mktemp -d)
   ZIP_DST="$AWS_CLI_INSTALL_DIR"/awscliv2.zip
   add_gpg_key A6310ACC4672475C

--- a/n_utils/includes/tool_installers.sh
+++ b/n_utils/includes/tool_installers.sh
@@ -306,13 +306,16 @@ MARKER
 
 install_rust_toolchain() {
   # https://rustup.rs/
-  curl https://sh.rustup.rs -sSf | sh -s -- -y
+  # https://forge.rust-lang.org/infra/other-installation-methods.html#rustup
+  curl -s "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" -o rustup-init
+  ./rustup-init -y
   source "$HOME/.cargo/env"
   "$HOME/.cargo/bin/rustup" --version
   "$HOME/.cargo/bin/rustup" update
   "$HOME/.cargo/bin/rustc" --version
   "$HOME/.cargo/bin/rustup" component add rustfmt
   "$HOME/.cargo/bin/rustup" component add clippy
+  rm rustup-init
 }
 
 install_github_actions_runner() {

--- a/n_utils/includes/tool_installers.sh
+++ b/n_utils/includes/tool_installers.sh
@@ -52,6 +52,9 @@ if [ -z "$GITHUB_RUNNER_VERSION" ]; then
   GITHUB_RUNNER_VERSION=2.303.0
   GITHUB_RUNNER_CSUM=e4a9fb7269c1a156eb5d5369232d0cd62e06bec2fd2b321600e85ac914a9cc73
 fi
+if [ -z "$RUSTUP_INIT_CSUM" ]; then
+  RUSTUP_INIT_CSUM=bb31eaf643926b2ee9f4d8d6fc0e2835e03c0a60f34d324048aa194f0b29a71c
+fi
 
 # Make sure we get logging
 if ! grep cloud-init-output.log /etc/cloud/cloud.cfg.d/05_logging.cfg > /dev/null; then
@@ -307,15 +310,20 @@ MARKER
 install_rust_toolchain() {
   # https://rustup.rs/
   # https://forge.rust-lang.org/infra/other-installation-methods.html#rustup
-  curl -s "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" -o rustup-init
-  ./rustup-init -y
+  local URL
+  local FILE
+  URL="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"
+  FILE="$(basename "$URL")"
+  safe_download "$URL" "$RUSTUP_INIT_CSUM" "$FILE"
+  file "$FILE"
+  ./"$FILE" -y
   source "$HOME/.cargo/env"
   "$HOME/.cargo/bin/rustup" --version
   "$HOME/.cargo/bin/rustup" update
   "$HOME/.cargo/bin/rustc" --version
   "$HOME/.cargo/bin/rustup" component add rustfmt
   "$HOME/.cargo/bin/rustup" component add clippy
-  rm rustup-init
+  rm -f "$FILE"
 }
 
 install_github_actions_runner() {

--- a/n_utils/includes/tool_installers.sh
+++ b/n_utils/includes/tool_installers.sh
@@ -310,12 +310,12 @@ MARKER
 install_rust_toolchain() {
   # https://rustup.rs/
   # https://forge.rust-lang.org/infra/other-installation-methods.html#rustup
+  source $(n-include common_tools.sh)
   local URL
   local FILE
   URL="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"
   FILE="$(basename "$URL")"
   safe_download "$URL" "$RUSTUP_INIT_CSUM" "$FILE"
-  file "$FILE"
   ./"$FILE" -y
   source "$HOME/.cargo/env"
   "$HOME/.cargo/bin/rustup" --version
@@ -327,10 +327,10 @@ install_rust_toolchain() {
 }
 
 install_github_actions_runner() {
-  local URL
-  local FILE
   source $(n-include common_tools.sh)
   mkdir /opt/github-runner
+  local URL
+  local FILE
   URL="https://github.com/actions/runner/releases/download/v$GITHUB_RUNNER_VERSION/actions-runner-linux-x64-$GITHUB_RUNNER_VERSION.tar.gz"
   FILE="$(basename "$URL")"
   safe_download "$URL" "$GITHUB_RUNNER_CSUM" "$FILE"

--- a/n_utils/includes/tool_installers.sh
+++ b/n_utils/includes/tool_installers.sh
@@ -304,6 +304,17 @@ MARKER
   yes | flutter doctor --android-licenses
 }
 
+install_rust_toolchain() {
+  # https://rustup.rs/
+  curl https://sh.rustup.rs -sSf | sh -s -- -y
+  source "$HOME/.cargo/env"
+  "$HOME/.cargo/bin/rustup" --version
+  "$HOME/.cargo/bin/rustup" update
+  "$HOME/.cargo/bin/rustc" --version
+  "$HOME/.cargo/bin/rustup" component add rustfmt
+  "$HOME/.cargo/bin/rustup" component add clippy
+}
+
 install_github_actions_runner() {
   source $(n-include common_tools.sh)
   mkdir /opt/github-runner


### PR DESCRIPTION
Add `install_rust_toolchain` to install a full rust toolchain with cargo, rustfmt and clippy using rustup