### PR TITLE
Modernize faster aws profile print

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,21 @@
+# Faster register complete binaries for ndt
+
 cmake_minimum_required(VERSION 3.18)
 
-project("nameless-dt-binaries" VERSION 1.0 LANGUAGES CXX)
+project("nameless-dt-binaries"
+    VERSION 1.0
+    LANGUAGES CXX
+    DESCRIPTION "Faster register complete binaries for nameless-deploy-tools."
+    HOMEPAGE_URL "https://github.com/NitorCreations/nameless-deploy-tools"
+)
 
 set(CMAKE_CXX_STANDARD 20)
+
+# Export compile commands for clang-tidy
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+message(STATUS "CMake version: ${CMAKE_VERSION}")
+message(STATUS "CMake source dir: ${CMAKE_SOURCE_DIR}")
 
 include_directories(n_utils)
 

--- a/faster_register_complete.sh
+++ b/faster_register_complete.sh
@@ -70,8 +70,7 @@ else
 fi
 
 if [ -z "$(command -v "$COMPILER")" ]; then
-  echo "Compiler not found: $COMPILER"
-  exit 1
+  print_error_and_exit "Compiler not found: $COMPILER"
 fi
 
 $COMPILER --version

--- a/n_utils/nameless-dt-print-aws-profiles.cpp
+++ b/n_utils/nameless-dt-print-aws-profiles.cpp
@@ -1,51 +1,49 @@
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <unordered_set>
+#include <set>
+#include <string_view>
 
-int main(int argc, const char* argv[]) {
-    std::string prefix = "";
-    std::unordered_set<std::string> ret;
+/// Print all unique AWS profile names found from config.
+int main(const int argc, const char* argv[]) {
+    const auto home = std::getenv("HOME");
+    if (!home) {
+        return 0;
+    }
+
+    std::string_view prefix;
+    std::set<std::string> profiles;
     if (argc > 1) {
         prefix = argv[1];
     }
-    if (!getenv("HOME")) {
-        return 0;
-    }
-    std::string home = getenv("HOME");
-    std::ifstream credentials(home + "/.aws/credentials", std::fstream::in);
-    if (credentials) {
-        std::string line;
-        while (getline(credentials, line)) {
-            if (line[0] != '[' || line[line.length() - 1] != ']') {
-                continue;
-            }
-            std::string profile_name = line.substr(1, line.length() - 2);
-            if (strncmp(profile_name.c_str(), prefix.c_str(), prefix.size()) == 0) {
-                ret.insert(profile_name);
-            }
-        }
-        credentials.close();
-    }
-    std::ifstream config(home + "/.aws/config", std::fstream::in);
-    if (config) {
-        std::string line;
-        while (getline(config, line)) {
-            if (line[0] != '[' || line[line.length() - 1] != ']') {
-                continue;
-            }
-            std::string profile_name = line.substr(9, line.length() - 10);
-            if (strncmp(profile_name.c_str(), prefix.c_str(), prefix.size()) == 0) {
-                ret.insert(profile_name);
+
+    // Lambda function to extract aws profile names from a file
+    auto get_aws_profiles = [&](const std::filesystem::path& path, const size_t profile_name_start_offset, const size_t profile_name_end_offset) {
+        std::ifstream file(path, std::fstream::in);
+        if (file) {
+            std::string line;
+            while (std::getline(file, line)) {
+                if (!line.starts_with('[') || !line.ends_with(']')) {
+                    continue;
+                }
+                auto profile_name = std::string_view(line).substr(profile_name_start_offset, line.length() - profile_name_end_offset);
+                if (!profile_name.empty() && profile_name.starts_with(prefix)) {
+                    profiles.insert(std::string(profile_name));
+                }
             }
         }
-        config.close();
+    };
+
+    const std::filesystem::path credentials_path = std::filesystem::path(home) / ".aws" / "credentials";
+    get_aws_profiles(credentials_path, 1, 2);
+
+    const std::filesystem::path config_path = std::filesystem::path(home) / ".aws" / "config";
+    get_aws_profiles(config_path, 9, 10);
+
+    for (const auto& profile : profiles) {
+        std::cout << profile << ' ';
     }
-    std::string res;
-    for (auto profile : ret) {
-        res.append(profile);
-        res.push_back(' ');
-    }
-    std::cout << res << std::endl;
+    std::cout << std::endl;
     return 0;
 }

--- a/n_utils/nameless-dt-print-aws-profiles.cpp
+++ b/n_utils/nameless-dt-print-aws-profiles.cpp
@@ -35,10 +35,10 @@ int main(const int argc, const char* argv[]) {
         }
     };
 
-    const std::filesystem::path credentials_path = std::filesystem::path(home) / ".aws" / "credentials";
+    const auto credentials_path = std::filesystem::path(home) / ".aws" / "credentials";
     get_aws_profiles(credentials_path, 1, 2);
 
-    const std::filesystem::path config_path = std::filesystem::path(home) / ".aws" / "config";
+    const auto config_path = std::filesystem::path(home) / ".aws" / "config";
     get_aws_profiles(config_path, 9, 10);
 
     for (const auto& profile : profiles) {

--- a/n_utils/nameless-dt-print-aws-profiles.cpp
+++ b/n_utils/nameless-dt-print-aws-profiles.cpp
@@ -1,8 +1,9 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <string>
+#include <numeric>
 #include <set>
+#include <string>
 #include <string_view>
 
 /// Print all unique AWS profile names found from config.
@@ -19,7 +20,9 @@ int main(const int argc, const char* argv[]) {
     }
 
     // Lambda function to extract aws profile names from a file
-    auto get_aws_profiles = [&](const std::filesystem::path& path, const size_t profile_name_start_offset, const size_t profile_name_end_offset) {
+    auto get_aws_profiles = [&](const std::filesystem::path& path,
+                                const size_t profile_name_start_offset,
+                                const size_t profile_name_end_offset) {
         std::ifstream file(path, std::fstream::in);
         if (file) {
             std::string line;
@@ -27,7 +30,8 @@ int main(const int argc, const char* argv[]) {
                 if (!line.starts_with('[') || !line.ends_with(']')) {
                     continue;
                 }
-                auto profile_name = std::string_view(line).substr(profile_name_start_offset, line.length() - profile_name_end_offset);
+                auto profile_name
+                    = std::string_view(line).substr(profile_name_start_offset, line.length() - profile_name_end_offset);
                 if (!profile_name.empty() && profile_name.starts_with(prefix)) {
                     profiles.insert(std::string(profile_name));
                 }
@@ -41,9 +45,18 @@ int main(const int argc, const char* argv[]) {
     const auto config_path = std::filesystem::path(home) / ".aws" / "config";
     get_aws_profiles(config_path, 9, 10);
 
+    const size_t total_string_length
+        = std::accumulate(profiles.begin(), profiles.end(), 0, [](const size_t sum, const std::string& profile) {
+              // +1 for the space
+              return sum + profile.length() + 1;
+          });
+
+    std::string result;
+    // Pre-allocate memory. Probably not much faster unless there would be a lot of profiles :)
+    result.reserve(total_string_length);
     for (const auto& profile : profiles) {
-        std::cout << profile << ' ';
+        result += profile + " ";
     }
-    std::cout << std::endl;
+    std::cout << result << std::endl;
     return 0;
 }

--- a/n_utils/ndt.py
+++ b/n_utils/ndt.py
@@ -94,7 +94,8 @@ def do_command_completion():
 
 
 def ndt():
-    """The main nameless deploy tools command that provides bash command
+    """
+    The main nameless deploy tools command that provides bash command
     completion and subcommand execution
     """
     do_profile = False

--- a/n_utils/profile_util.py
+++ b/n_utils/profile_util.py
@@ -159,7 +159,7 @@ def check_profile_expired(profile, profile_type=None):
 def print_aws_profiles():
     """
     Prints profile names from the credentials file (~/.aws/credentials),
-    and the confing file (~/.aws/config) for autocomplete tools.
+    and the config file (~/.aws/config) for autocomplete tools.
     """
     parser = argparse.ArgumentParser(description=print_aws_profiles.__doc__)
     if "_ARGCOMPLETE" in os.environ:


### PR DESCRIPTION
Modernize `nameless-dt-print-aws-profiles.cpp`: use C++17 and C++20 stuff 🤓 

Swapped to the basic `set` from `unordered_set` since set keeps things sorted so nicer print. 

```console
➜  nameless-deploy-tools git:(modernize-profile-cpp-print)
time ndt print-aws-profiles
nitor-core nitor-infra nitor-web nitor-ironbank
ndt print-aws-profiles  0.17s user 0.06s system 48% cpu 0.469 total
➜  nameless-deploy-tools git:(modernize-profile-cpp-print)
time nameless-dt-print-aws-profiles
nitor-core nitor-infra nitor-ironbank nitor-web
nameless-dt-print-aws-profiles  0.00s user 0.00s system 1% cpu 0.219 total
```